### PR TITLE
feat: Allow typed contexts to be created without request

### DIFF
--- a/thruster-proc/Cargo.toml
+++ b/thruster-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-proc"
-version = "0.9.0-alpha.9"
+version = "0.9.0-alpha.10"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The proc macros behind the thruster web framework"
 readme = "README.md"

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.9.0-alpha.9"
+version = "0.9.0-alpha.10"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"
@@ -84,7 +84,7 @@ file = [
 async-trait = "0.1"
 hyperlocal = { version = "0.7.0", optional = true }
 hyper = { version = "0.13.1", optional = true }
-thruster-proc = "=0.9.0-alpha.8"
+thruster-proc = "=0.9.0-alpha.10"
 bytes = "0.5.4"
 chashmap = { version = "2.2", optional = true }
 futures-legacy = { version = "0.1.23", package = "futures" }

--- a/thruster/src/context/typed_hyper_context.rs
+++ b/thruster/src/context/typed_hyper_context.rs
@@ -93,6 +93,26 @@ impl<S> TypedHyperContext<S> {
         ctx
     }
 
+    pub fn new_without_request(extra: S) -> TypedHyperContext<S> {
+        let params = HashMap::new();
+        let mut ctx = TypedHyperContext {
+            body: Body::empty(),
+            query_params: HashMap::new(),
+            headers: HashMap::new(),
+            status: 200,
+            params,
+            hyper_request: None,
+            request_body: None,
+            request_parts: None,
+            extra,
+            http_version: hyper::Version::HTTP_11
+        };
+
+        ctx.set("Server", "Thruster");
+
+        ctx
+    }
+
     ///
     /// Set the body as a string
     ///


### PR DESCRIPTION
This is helpful for creating new contexts without needing to replicate the request (if it's not needed.)