### PR TITLE
feat: Upgrade hyper_ssl_server to use rustls

### DIFF
--- a/thruster-proc/Cargo.toml
+++ b/thruster-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-proc"
-version = "0.9.0-alpha.13"
+version = "0.9.0-alpha.14"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The proc macros behind the thruster web framework"
 readme = "README.md"

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "0.9.0-alpha.13"
+version = "0.9.0-alpha.14"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "README.md"
@@ -74,7 +74,8 @@ unix_hyper_server = [
 ]
 tls = [
   "native-tls",
-  "tokio-tls",
+  "tokio-rustls",
+  "tokio-native-tls",
 ]
 file = [
   "chashmap",
@@ -84,7 +85,7 @@ file = [
 async-trait = "0.1"
 hyperlocal = { version = "0.7.0", optional = true }
 hyper = { version = "0.13.1", optional = true }
-thruster-proc = "=0.9.0-alpha.12"
+thruster-proc = "=0.9.0-alpha.14"
 bytes = "0.5.4"
 chashmap = { version = "2.2", optional = true }
 futures-legacy = { version = "0.1.23", package = "futures" }
@@ -100,7 +101,8 @@ serde = "1.0.24"
 serde_json = "1.0.8"
 serde_derive = "1.0.24"
 tokio = { version = "0.2", features = ["full"] }
-tokio-tls = { version = "0.3", optional = true }
+tokio-native-tls = { version = "0.1.0", optional = true }
+tokio-rustls = { version = "0.14.0", optional = true }
 tokio-util = { version = "0.2", features = ["full"] }
 native-tls = { version = "0.2", optional = true }
 time = "0.1"

--- a/thruster/src/server/ssl_server.rs
+++ b/thruster/src/server/ssl_server.rs
@@ -70,7 +70,7 @@ impl<T: Context<Response = Response> + Send, S: 'static + Send + Sync> ThrusterS
         let cert = self.cert.unwrap().clone();
         let cert_pass = self.cert_pass;
         let cert = Identity::from_pkcs12(&cert, cert_pass).expect("Could not decrypt p12 file");
-        let tls_acceptor = tokio_tls::TlsAcceptor::from(
+        let tls_acceptor = tokio_native_tls::TlsAcceptor::from(
             native_tls::TlsAcceptor::builder(cert)
                 .build()
                 .expect("Could not create TLS acceptor."),
@@ -90,7 +90,7 @@ impl<T: Context<Response = Response> + Send, S: 'static + Send + Sync> ThrusterS
         // TODO(trezm): Add an argument here for the tls_acceptor to be passed in.
         async fn process<T: Context<Response = Response> + Send, S: Send>(
             app: Arc<App<Request, T, S>>,
-            tls_acceptor: Arc<tokio_tls::TlsAcceptor>,
+            tls_acceptor: Arc<tokio_native_tls::TlsAcceptor>,
             socket: TcpStream,
         ) -> Result<(), Box<dyn Error>> {
             let tls = tls_acceptor.accept(socket).await?;


### PR DESCRIPTION
[rustls](https://github.com/ctz/rustls) has proven to be able to handle edge cases better than native-tls in many circumstances. It's also nice to have a safe rust-based solution.