### PR TITLE
switch chashmap for dashmap

### DIFF
--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -78,7 +78,7 @@ tls = [
   "tokio-native-tls",
 ]
 file = [
-  "chashmap",
+  "dashmap",
 ]
 
 [dependencies]
@@ -87,7 +87,7 @@ hyperlocal = { version = "0.7.0", optional = true }
 hyper = { version = "0.13.1", optional = true }
 thruster-proc = "=1.0.0"
 bytes = "0.5.4"
-chashmap = { version = "2.2", optional = true }
+dashmap = { version = "3.11.9", optional = true }
 futures-legacy = { version = "0.1.23", package = "futures" }
 futures = "0.3"
 http = "0.2"

--- a/thruster/src/middleware/file.rs
+++ b/thruster/src/middleware/file.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use bytes::BytesMut;
-use chashmap::CHashMap;
+use dashmap::DashMap;
 use lazy_static::*;
 use std::env;
 use std::fs::File;
@@ -14,7 +14,7 @@ use crate::core::{MiddlewareNext, MiddlewareResult};
 use crate::map_try;
 
 lazy_static! {
-    static ref CACHE: CHashMap<String, Vec<u8>> = CHashMap::new();
+    static ref CACHE: DashMap<String, Vec<u8>> = DashMap::new();
     ///
     /// ROOT_DIR, stored in the RUST_ROOT_DIR env var dictates where
     /// the `file` middleware serves from.
@@ -37,7 +37,7 @@ lazy_static! {
 ///
 /// `file`, and the underlying `get_file`, also attempt to cache
 /// any files that it reads. The underlying data is stored in a
-/// CHashMap. This feature can be turned off by setting the env
+/// DashMap. This feature can be turned off by setting the env
 /// var RUST_CACHE=off
 ///
 #[middleware_fn(_internal)]


### PR DESCRIPTION
dashmap is a more performant and maintained alternative to chashmap.
chashmap is no longer maintained.