### PR TITLE
feat: Improve hyper related performance

### DIFF
--- a/thruster-proc/src/lib.rs
+++ b/thruster-proc/src/lib.rs
@@ -19,7 +19,10 @@ pub fn middleware_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
             syn::FnArg::Captured(cap) => &cap.ty,
             _ => panic!("Expected the first argument to be a context type"),
         };
-        let new_return_type = Ident::new(&format!("__MiddlewareReturnValue_{}", name.clone()), Span2::call_site());
+        let new_return_type = Ident::new(
+            &format!("__MiddlewareReturnValue_{}", name.clone()),
+            Span2::call_site(),
+        );
         let crate_path = match attr.to_string().as_str() {
             "_internal" => quote! {
                 crate::core::{ MiddlewareReturnValue as #new_return_type }

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -92,7 +92,7 @@ futures-legacy = { version = "0.1.23", package = "futures" }
 futures = "0.3"
 http = "0.2"
 httplib = { package = "http", version = "0.1.7" }
-httparse = "1.1.2"
+httparse = "1.3.4"
 lazy_static = "1.4.0"
 log = "0.4"
 net2 = "0.2"

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -32,6 +32,10 @@ name = "hyper_most_basic"
 required-features = ["hyper_server"]
 
 [[example]]
+name = "fast_hyper"
+required-features = ["hyper_server"]
+
+[[example]]
 name = "hyper_most_basic_ssl"
 required-features = ["hyper_server", "tls"]
 

--- a/thruster/examples/fast_hyper.rs
+++ b/thruster/examples/fast_hyper.rs
@@ -11,11 +11,12 @@ use thruster::{MiddlewareNext, MiddlewareResult};
 #[middleware_fn]
 async fn plaintext(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
     let val = "Hello, World!";
-    context.body = Body::from(val);
+    context.body = Some(Body::from(val));
     Ok(context)
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init();
     info!("Starting server...");
 
@@ -23,5 +24,5 @@ fn main() {
     app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
 
     let server = HyperServer::new(app);
-    server.start("0.0.0.0", 4321);
+    server.build("0.0.0.0", 4321).await;
 }

--- a/thruster/examples/fast_hyper.rs
+++ b/thruster/examples/fast_hyper.rs
@@ -1,7 +1,7 @@
 use hyper::Body;
 use log::info;
-use thruster::context::basic_hyper_context::{
-    generate_context, BasicHyperContext as Ctx, HyperRequest,
+use thruster::context::fast_hyper_context::{
+    generate_context, FastHyperContext as Ctx, HyperRequest,
 };
 use thruster::hyper_server::HyperServer;
 use thruster::{async_middleware, middleware_fn};

--- a/thruster/examples/hyper_most_basic.rs
+++ b/thruster/examples/hyper_most_basic.rs
@@ -23,5 +23,7 @@ fn main() {
     app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
 
     let server = HyperServer::new(app);
-    server.start("0.0.0.0", 4322);
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(server.build_per_thread("0.0.0.0", 4321))
 }

--- a/thruster/src/context/basic_context.rs
+++ b/thruster/src/context/basic_context.rs
@@ -21,8 +21,8 @@ pub fn generate_context<S>(request: Request, _state: &S, _path: &str) -> BasicCo
 pub struct BasicContext {
     response: Response,
     pub cookies: Vec<Cookie>,
-    pub params: HashMap<String, String>,
-    pub query_params: HashMap<String, String>,
+    pub params: Option<HashMap<String, String>>,
+    pub query_params: Option<HashMap<String, String>>,
     pub request: Request,
     pub status: u32,
     pub headers: HashMap<String, String>,
@@ -33,8 +33,8 @@ impl BasicContext {
         let mut ctx = BasicContext {
             response: Response::new(),
             cookies: Vec::new(),
-            params: HashMap::new(),
-            query_params: HashMap::new(),
+            params: None,
+            query_params: None,
             request: Request::new(),
             headers: HashMap::new(),
             status: 200,
@@ -170,7 +170,7 @@ impl Context for BasicContext {
 
 impl HasQueryParams for BasicContext {
     fn set_query_params(&mut self, query_params: HashMap<String, String>) {
-        self.query_params = query_params;
+        self.query_params = Some(query_params);
     }
 }
 

--- a/thruster/src/context/basic_hyper_context.rs
+++ b/thruster/src/context/basic_hyper_context.rs
@@ -68,7 +68,7 @@ pub struct BasicHyperContext {
     pub body: Body,
     pub query_params: HashMap<String, String>,
     pub status: u16,
-    pub params: HashMap<String, String>,
+    pub params: Option<HashMap<String, String>>,
     pub hyper_request: Option<HyperRequest>,
     request_body: Option<Body>,
     request_parts: Option<Parts>,

--- a/thruster/src/context/fast_hyper_context.rs
+++ b/thruster/src/context/fast_hyper_context.rs
@@ -1,0 +1,78 @@
+use bytes::Bytes;
+use http::header::{HeaderMap, HeaderName, HeaderValue, SERVER};
+use hyper::{Body, Response, StatusCode};
+use std::str;
+
+pub use crate::context::hyper_request::HyperRequest;
+use crate::core::context::Context;
+
+pub fn generate_context<S>(request: HyperRequest, _state: &S, _path: &str) -> FastHyperContext {
+    FastHyperContext::new(request)
+}
+
+#[derive(Default)]
+pub struct FastHyperContext {
+    pub body: Body,
+    pub status: u16,
+    pub hyper_request: Option<HyperRequest>,
+    pub http_version: hyper::Version,
+    headers: HeaderMap,
+}
+
+const SERVER_HEADER_NAME: HeaderName = SERVER;
+impl FastHyperContext {
+    pub fn new(req: HyperRequest) -> FastHyperContext {
+        let mut headers = HeaderMap::new();
+        headers.insert(SERVER_HEADER_NAME, HeaderValue::from_static("thruster"));
+
+        FastHyperContext {
+            body: Body::empty(),
+            status: 200,
+            hyper_request: Some(req),
+            http_version: hyper::Version::HTTP_11,
+            headers,
+        }
+    }
+}
+
+impl Context for FastHyperContext {
+    type Response = Response<Body>;
+
+    fn get_response(self) -> Self::Response {
+        let mut response = Response::new(self.body);
+
+        *response.status_mut() = StatusCode::from_u16(self.status).unwrap();
+        *response.headers_mut() = self.headers;
+        *response.version_mut() = self.http_version;
+
+        response
+    }
+
+    fn set_body(&mut self, body: Vec<u8>) {
+        self.body = Body::from(body);
+    }
+
+    fn set_body_bytes(&mut self, bytes: Bytes) {
+        self.body = Body::from(bytes);
+    }
+
+    fn route(&self) -> &str {
+        let uri = self.hyper_request.as_ref().unwrap().request.uri();
+
+        match uri.path_and_query() {
+            Some(val) => val.as_str(),
+            None => uri.path(),
+        }
+    }
+
+    fn set(&mut self, key: &str, value: &str) {
+        self.headers.insert(
+            HeaderName::from_bytes(key.as_bytes()).unwrap(),
+            HeaderValue::from_str(value).unwrap(),
+        );
+    }
+
+    fn remove(&mut self, key: &str) {
+        self.headers.remove(key);
+    }
+}

--- a/thruster/src/context/hyper_request.rs
+++ b/thruster/src/context/hyper_request.rs
@@ -8,7 +8,7 @@ pub struct HyperRequest {
     pub request: Request<Body>,
     pub parts: Option<Parts>,
     pub body: Option<Body>,
-    pub params: HashMap<String, String>,
+    pub params: Option<HashMap<String, String>>,
 }
 
 impl HyperRequest {
@@ -17,13 +17,13 @@ impl HyperRequest {
             request,
             parts: None,
             body: None,
-            params: HashMap::new(),
+            params: None,
         }
     }
 }
 
 impl RequestWithParams for HyperRequest {
-    fn set_params(&mut self, params: HashMap<String, String>) {
+    fn set_params(&mut self, params: Option<HashMap<String, String>>) {
         self.params = params;
     }
 }

--- a/thruster/src/context/mod.rs
+++ b/thruster/src/context/mod.rs
@@ -7,4 +7,7 @@ pub mod basic_hyper_context;
 pub mod typed_hyper_context;
 
 #[cfg(feature = "hyper_server")]
+pub mod fast_hyper_context;
+
+#[cfg(feature = "hyper_server")]
 pub mod hyper_request;

--- a/thruster/src/core/request.rs
+++ b/thruster/src/core/request.rs
@@ -147,6 +147,7 @@ pub fn decode(buf: &mut BytesMut) -> io::Result<Option<Request>> {
         let status = r.parse(buf).map_err(|e| {
             let msg = format!("failed to parse http request: {:?}", e);
             eprintln!("msg: {}", msg);
+            eprintln!("dump: {:#?}", buf);
             io::Error::new(io::ErrorKind::Other, msg)
         })?;
         let amt = match status {

--- a/thruster/src/core/request.rs
+++ b/thruster/src/core/request.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::{fmt, io, str};
 
 pub trait RequestWithParams {
-    fn set_params(&mut self, _: HashMap<String, String>);
+    fn set_params(&mut self, _: Option<HashMap<String, String>>);
 }
 
 ///
@@ -20,7 +20,7 @@ pub struct Request {
     version: u8,
     pub headers: SmallVec<[(Slice, Slice); 8]>,
     data: BytesMut,
-    pub params: HashMap<String, String>,
+    pub params: Option<HashMap<String, String>>,
 }
 
 type Slice = (usize, usize);
@@ -37,7 +37,7 @@ impl Request {
             version: 0,
             headers: SmallVec::new(),
             data: BytesMut::new(),
-            params: HashMap::new(),
+            params: None,
         }
     }
 
@@ -119,13 +119,13 @@ impl Request {
     /// Fetch the params from the route, e.g. The route "/some/:key" when applied to an incoming
     /// request for "/some/value" will populate `params` with `{ key: "value" }`
     ///
-    pub fn params(&self) -> &HashMap<String, String> {
+    pub fn params(&self) -> &Option<HashMap<String, String>> {
         &self.params
     }
 }
 
 impl RequestWithParams for Request {
-    fn set_params(&mut self, params: HashMap<String, String>) {
+    fn set_params(&mut self, params: Option<HashMap<String, String>>) {
         self.params = params;
     }
 }
@@ -190,7 +190,7 @@ pub fn decode(buf: &mut BytesMut) -> io::Result<Option<Request>> {
             headers,
             data: buf.split_to(amt + body_len),
             body: (amt, amt + body_len),
-            params: HashMap::new(),
+            params: None,
         }
         .into())
     }

--- a/thruster/src/core/route_parser.rs
+++ b/thruster/src/core/route_parser.rs
@@ -9,8 +9,8 @@ pub struct MatchedRoute<'a, 'b, T: 'static + Context + Send> {
     pub middleware: &'a MiddlewareChain<T>,
     pub value: String,
     pub path: &'b str,
-    pub params: HashMap<String, String>,
-    pub query_params: HashMap<String, String>,
+    pub params: Option<HashMap<String, String>>,
+    pub query_params: Option<HashMap<String, String>>,
 }
 
 pub struct RouteParser<T: 'static + Context + Send> {
@@ -49,8 +49,6 @@ impl<T: Context + Send> RouteParser<T> {
 
     #[inline]
     pub fn match_route<'a>(&'a self, route: String) -> MatchedRoute<'a, '_, T> {
-        let query_params = HashMap::new();
-
         let split_route = route.find('?');
         let mut no_query_route = match split_route {
             Some(index) => &route[0..index],
@@ -67,8 +65,8 @@ impl<T: Context + Send> RouteParser<T> {
                 middleware: shortcut,
                 value: route,
                 path,
-                params: HashMap::new(),
-                query_params,
+                params: None,
+                query_params: None,
             }
         } else {
             let matched = self.route_tree.match_route(&no_query_route);
@@ -78,7 +76,7 @@ impl<T: Context + Send> RouteParser<T> {
                 value: route,
                 path: matched.2,
                 params: matched.0,
-                query_params,
+                query_params: None,
             }
         }
     }

--- a/thruster/src/core/route_tree/mod.rs
+++ b/thruster/src/core/route_tree/mod.rs
@@ -52,11 +52,12 @@ impl<T: 'static + Context + Send> RouteTree<T> {
         root_node
             .push_middleware_to_populated_nodes(&self.generic_root_node, &MiddlewareChain::new());
 
-            self.root_node = root_node;
+        self.root_node = root_node;
     }
 
     pub fn add_use_node(&mut self, route: &str, middleware: MiddlewareChain<T>) {
-        self.generic_root_node.add_route(route, middleware, route.to_string());
+        self.generic_root_node
+            .add_route(route, middleware, route.to_string());
         self.update_root_node();
     }
 
@@ -70,12 +71,14 @@ impl<T: 'static + Context + Send> RouteTree<T> {
 
         let full_route = format!("{}{}", prefix, route);
 
-        self.specific_root_node.add_route(&full_route, middleware, full_route.clone());
+        self.specific_root_node
+            .add_route(&full_route, middleware, full_route.clone());
         self.update_root_node();
     }
 
     pub fn add_route(&mut self, route: &str, middleware: MiddlewareChain<T>) {
-        self.specific_root_node.add_route(route, middleware, route.to_string());
+        self.specific_root_node
+            .add_route(route, middleware, route.to_string());
         self.update_root_node();
     }
 
@@ -115,7 +118,10 @@ impl<T: 'static + Context + Send> RouteTree<T> {
         self.update_root_node();
     }
 
-    pub fn match_route(&self, route: &str) -> (HashMap<String, String>, &MiddlewareChain<T>, &str) {
+    pub fn match_route(
+        &self,
+        route: &str,
+    ) -> (Option<HashMap<String, String>>, &MiddlewareChain<T>, &str) {
         let results = self.root_node.match_route(route.split('/'));
 
         (results.0, results.2, results.3)
@@ -124,8 +130,8 @@ impl<T: 'static + Context + Send> RouteTree<T> {
     pub fn match_route_with_params(
         &self,
         route: &str,
-        params: HashMap<String, String>,
-    ) -> (HashMap<String, String>, &MiddlewareChain<T>, &str) {
+        params: Option<HashMap<String, String>>,
+    ) -> (Option<HashMap<String, String>>, &MiddlewareChain<T>, &str) {
         let results = self
             .root_node
             .match_route_with_params(route.split('/'), params);

--- a/thruster/src/lib.rs
+++ b/thruster/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(thread_id_value)]
+
 #[macro_use]
 extern crate templatify;
 

--- a/thruster/src/lib.rs
+++ b/thruster/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(thread_id_value)]
-
 #[macro_use]
 extern crate templatify;
 

--- a/thruster/src/server/hyper_server.rs
+++ b/thruster/src/server/hyper_server.rs
@@ -1,15 +1,16 @@
-use std::net::ToSocketAddrs;
-
 use async_trait::async_trait;
 use hyper::server::conn::Http;
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Request, Response, Server};
+use hyper::service::make_service_fn;
+use hyper::service::Service;
+use hyper::{Body, Request, Response};
 #[cfg(not(windows))]
 use net2::unix::UnixTcpBuilderExt;
-use net2::TcpBuilder;
+use std::future::Future;
 use std::net::SocketAddr;
+use std::net::ToSocketAddrs;
+use std::pin::Pin;
 use std::sync::Arc;
-use tokio::stream::StreamExt;
+use std::task::{Context as TaskContext, Poll};
 
 use crate::app::App;
 use crate::context::hyper_request::HyperRequest;
@@ -20,56 +21,34 @@ pub struct HyperServer<T: 'static + Context + Send, S: Send> {
     app: App<HyperRequest, T, S>,
 }
 
-fn reuse_listener(
-    addr: &SocketAddr,
-    handle: &tokio::runtime::Handle,
-) -> std::io::Result<std::net::TcpListener> {
-    let builder = match *addr {
-        SocketAddr::V4(_) => net2::TcpBuilder::new_v4()?,
-        SocketAddr::V6(_) => net2::TcpBuilder::new_v6()?,
-    };
-
-    #[cfg(unix)]
-    {
-        use net2::unix::UnixTcpBuilderExt;
-        if let Err(e) = builder.reuse_port(true) {
-            eprintln!("error setting SO_REUSEPORT: {}", e);
-        }
-    }
-
-    builder.reuse_address(true)?;
-    builder.bind(addr)?;
-    builder.listen(1024)
-    // .and_then(|l| tokio::net::TcpListener::from_listener(l, addr, handle))
-}
-
 impl<T: Context<Response = Response<Body>> + Send, S: 'static + Send + Sync> HyperServer<T, S> {
     async fn process(
         arc_app: Arc<App<HyperRequest, T, S>>,
-        tcp_listener: std::net::TcpListener,
+        addr: &SocketAddr,
     ) -> Result<(), hyper::Error> {
+        let mut listener = {
+            let builder = net2::TcpBuilder::new_v4().unwrap();
+            #[cfg(not(windows))]
+            builder.reuse_address(true).unwrap();
+            #[cfg(not(windows))]
+            builder.reuse_port(true).unwrap();
+
+            builder.bind(addr).unwrap();
+            tokio::net::TcpListener::from_std(builder.listen(2048).unwrap()).unwrap()
+        };
+
+        let incoming = listener.incoming();
+
         let service = make_service_fn(|_| {
             let app = arc_app.clone();
 
-            async {
-                Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
-                    println!("cpu_id: {:?}", std::thread::current().id());
-                    let matched = app.resolve_from_method_and_path(
-                        &req.method().to_string(),
-                        &req.uri().path_and_query().unwrap().to_string(),
-                    );
-
-                    let req = HyperRequest::new(req);
-                    app.resolve(req, matched)
-                }))
-            }
+            async { Ok::<_, hyper::Error>(_HyperService { app }) }
         });
+        let server =
+            hyper::server::Builder::new(hyper::server::accept::from_stream(incoming), Http::new())
+                .serve(service);
 
-        let server = Server::from_tcp(tcp_listener).unwrap().serve(service);
-
-        println!("starting server on {:?}", std::thread::current().id());
         server.await?;
-        println!("server started...");
 
         Ok::<_, hyper::Error>(())
     }
@@ -79,73 +58,29 @@ impl<T: Context<Response = Response<Body>> + Send, S: 'static + Send + Sync> Hyp
         self.app._route_parser.optimize();
 
         let arc_app = Arc::new(self.app);
-
         let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
+
         for _ in 0..num_cpus::get() - 1 {
             let arc_app = arc_app.clone();
 
             std::thread::spawn(move || {
-                println!("spawned on thread {:?}", std::thread::current().id());
-
                 let mut rt = tokio::runtime::Builder::new()
-                    .basic_scheduler()
+                    .threaded_scheduler()
                     .enable_all()
                     .build()
                     .unwrap();
 
-                rt.handle().enter(|| {
-                    let mut rt = tokio::runtime::Builder::new()
-                        .basic_scheduler()
-                        .enable_all()
-                        .build()
-                        .unwrap();
-                    let mut listener = {
-                        let builder = net2::TcpBuilder::new_v4().unwrap();
-                        #[cfg(not(windows))]
-                        builder.reuse_address(true).unwrap();
-                        #[cfg(not(windows))]
-                        builder.reuse_port(true).unwrap();
-                        builder.bind(addr).unwrap();
-                        tokio::net::TcpListener::from_std(builder.listen(2048).unwrap()).unwrap()
-                    };
-
-                    rt.block_on(async move {
-                        let mut incoming = listener.incoming();
-                        let mut rt = tokio::runtime::Builder::new()
-                            .basic_scheduler()
-                            .enable_all()
-                            .build()
-                            .unwrap();
-
-                        while let Some(Ok(stream)) = incoming.next().await {
-                            let cloned = arc_app.clone();
-                            let mut http = Http::new();
-                            http.http1_only(true);
-                            http.pipeline_flush(true);
-
-                            let s = service_fn(move |req: Request<Body>| {
-                                println!("cpu_id: {:?}", std::thread::current().id());
-                                let matched = cloned.resolve_from_method_and_path(
-                                    &req.method().to_string(),
-                                    &req.uri().path_and_query().unwrap().to_string(),
-                                );
-
-                                let req = HyperRequest::new(req);
-                                cloned.resolve(req, matched)
-                            });
-
-                            rt.block_on(http.serve_connection(stream, s));
-                        }
-                    });
+                rt.block_on(async {
+                    Self::process(arc_app, &addr)
+                        .await
+                        .expect("Unable to spawn hyper server thread.");
                 });
             });
         }
 
-        println!("main thread: {:?}", std::thread::current().id());
-        let addr = ("0.0.0.0", 4322).to_socket_addrs().unwrap().next().unwrap();
-        Self::process(arc_app, std::net::TcpListener::bind(&addr).unwrap())
+        Self::process(arc_app, &addr)
             .await
-            .expect("hyper server failed");
+            .expect("Unable to spawn hyper server thread.");
     }
 }
 
@@ -168,29 +103,34 @@ impl<T: Context<Response = Response<Body>> + Send, S: 'static + Send + Sync> Thr
         let arc_app = Arc::new(self.app);
 
         let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
-        async move {
-            let service = make_service_fn(|_| {
-                let app = arc_app.clone();
+        Self::process(arc_app, &addr)
+            .await
+            .expect("hyper server failed");
+    }
+}
 
-                async {
-                    Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
-                        let matched = app.resolve_from_method_and_path(
-                            &req.method().to_string(),
-                            &req.uri().path_and_query().unwrap().to_string(),
-                        );
+struct _HyperService<T: 'static + Context + Send, S: Send> {
+    app: Arc<App<HyperRequest, T, S>>,
+}
 
-                        let req = HyperRequest::new(req);
-                        app.resolve(req, matched)
-                    }))
-                }
-            });
-            let server = Server::bind(&addr).serve(service);
+impl<T: 'static + Context + Send, S: 'static + Send> Service<Request<Body>>
+    for _HyperService<T, S>
+{
+    type Response = T::Response;
+    type Error = std::io::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
-            server.await?;
+    fn poll_ready(&mut self, _cx: &mut TaskContext<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
 
-            Ok::<_, hyper::Error>(())
-        }
-        .await
-        .expect("hyper server failed");
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let matched = self.app.resolve_from_method_and_path(
+            &req.method().to_string(),
+            &req.uri().path_and_query().unwrap().to_string(),
+        );
+
+        let req = HyperRequest::new(req);
+        Box::pin(self.app.resolve(req, matched))
     }
 }

--- a/thruster/src/server/hyper_server.rs
+++ b/thruster/src/server/hyper_server.rs
@@ -3,6 +3,7 @@ use std::net::ToSocketAddrs;
 use async_trait::async_trait;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use crate::app::App;
@@ -14,8 +15,95 @@ pub struct HyperServer<T: 'static + Context + Send, S: Send> {
     app: App<HyperRequest, T, S>,
 }
 
+fn reuse_listener(
+    addr: &SocketAddr,
+    handle: &tokio::runtime::Handle,
+) -> std::io::Result<std::net::TcpListener> {
+    let builder = match *addr {
+        SocketAddr::V4(_) => net2::TcpBuilder::new_v4()?,
+        SocketAddr::V6(_) => net2::TcpBuilder::new_v6()?,
+    };
+
+    #[cfg(unix)]
+    {
+        use net2::unix::UnixTcpBuilderExt;
+        if let Err(e) = builder.reuse_port(true) {
+            eprintln!("error setting SO_REUSEPORT: {}", e);
+        }
+    }
+
+    builder.reuse_address(true)?;
+    builder.bind(addr)?;
+    builder.listen(1024)
+    // .and_then(|l| tokio::net::TcpListener::from_listener(l, addr, handle))
+}
+
+impl<T: Context<Response = Response<Body>> + Send, S: 'static + Send + Sync> HyperServer<T, S> {
+    async fn process(
+        arc_app: Arc<App<HyperRequest, T, S>>,
+        tcp_listener: std::net::TcpListener,
+        cpu_id: Arc<usize>,
+    ) -> Result<(), hyper::Error> {
+        let service = make_service_fn(|_| {
+            let app = arc_app.clone();
+            let cpu_id = cpu_id.clone();
+
+            async {
+                Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
+                    println!("cpu_id: {}", cpu_id.clone());
+                    let matched = app.resolve_from_method_and_path(
+                        &req.method().to_string(),
+                        &req.uri().path_and_query().unwrap().to_string(),
+                    );
+
+                    let req = HyperRequest::new(req);
+                    app.resolve(req, matched)
+                }))
+            }
+        });
+
+        let server = Server::from_tcp(tcp_listener).unwrap().serve(service);
+
+        server.await?;
+
+        Ok::<_, hyper::Error>(())
+    }
+
+    #[allow(dead_code)]
+    pub async fn build_per_thread(mut self, host: &str, port: u16) {
+        self.app._route_parser.optimize();
+
+        let arc_app = Arc::new(self.app);
+
+        let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
+        let arc_addr = Arc::new(addr);
+        for i in 0..num_cpus::get() - 1 {
+            let arc_app = arc_app.clone();
+            let arc_addr = arc_addr.clone();
+            std::thread::spawn(move || {
+                let mut rt = tokio::runtime::Runtime::new().unwrap();
+                let tcp_listener = reuse_listener(&arc_addr.clone(), &rt.handle()).unwrap();
+                tokio::task::LocalSet::new().block_on(&mut rt, async move {
+                    Self::process(arc_app, tcp_listener, Arc::new(i))
+                        .await
+                        .expect("hyper server failed");
+                });
+            });
+        }
+
+        let handle = tokio::runtime::Handle::current();
+        let tcp_listener = reuse_listener(&arc_addr.clone(), &handle).unwrap();
+
+        Self::process(arc_app, tcp_listener, Arc::new(num_cpus::get() - 1))
+            .await
+            .expect("hyper server failed");
+    }
+}
+
 #[async_trait]
-impl<T: Context<Response = Response<Body>> + Send, S: 'static + Send + Sync> ThrusterServer for HyperServer<T, S> {
+impl<T: Context<Response = Response<Body>> + Send, S: 'static + Send + Sync> ThrusterServer
+    for HyperServer<T, S>
+{
     type Context = T;
     type Response = Response<Body>;
     type Request = HyperRequest;
@@ -29,8 +117,8 @@ impl<T: Context<Response = Response<Body>> + Send, S: 'static + Send + Sync> Thr
         self.app._route_parser.optimize();
 
         let arc_app = Arc::new(self.app);
-        let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
 
+        let addr = (host, port).to_socket_addrs().unwrap().next().unwrap();
         async move {
             let service = make_service_fn(|_| {
                 let app = arc_app.clone();
@@ -47,7 +135,6 @@ impl<T: Context<Response = Response<Body>> + Send, S: 'static + Send + Sync> Thr
                     }))
                 }
             });
-
             let server = Server::bind(&addr).serve(service);
 
             server.await?;


### PR DESCRIPTION
- Adds in a "fast" example.
- Replaces shortcut hashmap with a vec. The reasoning behind this is that for most reasonably sized apps with ~30 routes, iterating through a vec is _still_ faster than a hashmap lookup. After that point, it's slower.