### PR TITLE
bug: Fix status codes in the thruster error.

### DIFF
--- a/thruster/src/context/basic_context.rs
+++ b/thruster/src/context/basic_context.rs
@@ -60,13 +60,6 @@ impl BasicContext {
     }
 
     ///
-    /// Set the response status code
-    ///
-    pub fn status(&mut self, code: u32) {
-        self.status = code;
-    }
-
-    ///
     /// Set the response `Content-Type`. A shortcode for
     ///
     /// ```ignore
@@ -165,6 +158,10 @@ impl Context for BasicContext {
 
     fn remove(&mut self, key: &str) {
         self.headers.remove(key);
+    }
+
+    fn status(&mut self, code: u16) {
+        self.status = code as u32;
     }
 }
 

--- a/thruster/src/context/basic_context.rs
+++ b/thruster/src/context/basic_context.rs
@@ -60,6 +60,13 @@ impl BasicContext {
     }
 
     ///
+    /// Set the response status code
+    ///
+    pub fn status(&mut self, code: u32) {
+        self.status = code;
+    }
+
+    ///
     /// Set the response `Content-Type`. A shortcode for
     ///
     /// ```ignore

--- a/thruster/src/context/basic_hyper_context.rs
+++ b/thruster/src/context/basic_hyper_context.rs
@@ -162,6 +162,13 @@ impl BasicHyperContext {
     }
 
     ///
+    /// Set the response status code
+    ///
+    pub fn status(&mut self, code: u32) {
+        self.status = code.try_into().unwrap();
+    }
+
+    ///
     /// Set the response `Content-Type`. A shortcode for
     ///
     /// ```ignore

--- a/thruster/src/context/basic_hyper_context.rs
+++ b/thruster/src/context/basic_hyper_context.rs
@@ -162,13 +162,6 @@ impl BasicHyperContext {
     }
 
     ///
-    /// Set the response status code
-    ///
-    pub fn status(&mut self, code: u32) {
-        self.status = code.try_into().unwrap();
-    }
-
-    ///
     /// Set the response `Content-Type`. A shortcode for
     ///
     /// ```ignore
@@ -293,6 +286,10 @@ impl Context for BasicHyperContext {
 
     fn remove(&mut self, key: &str) {
         self.headers.remove(key);
+    }
+
+    fn status(&mut self, code: u16) {
+        self.status = code;
     }
 }
 

--- a/thruster/src/context/fast_hyper_context.rs
+++ b/thruster/src/context/fast_hyper_context.rs
@@ -96,4 +96,8 @@ impl Context for FastHyperContext {
             .headers_mut()
             .remove(key);
     }
+
+    fn status(&mut self, code: u16) {
+        self.status = code;
+    }
 }

--- a/thruster/src/context/typed_hyper_context.rs
+++ b/thruster/src/context/typed_hyper_context.rs
@@ -159,13 +159,6 @@ impl<S> TypedHyperContext<S> {
     }
 
     ///
-    /// Set the response status code
-    ///
-    pub fn status(&mut self, code: u32) {
-        self.status = code.try_into().unwrap();
-    }
-
-    ///
     /// Set the response `Content-Type`. A shortcode for
     ///
     /// ```ignore
@@ -291,6 +284,10 @@ impl<S> Context for TypedHyperContext<S> {
 
     fn remove(&mut self, key: &str) {
         self.headers.remove(key);
+    }
+
+    fn status(&mut self, code: u16) {
+        self.status = code;
     }
 }
 

--- a/thruster/src/context/typed_hyper_context.rs
+++ b/thruster/src/context/typed_hyper_context.rs
@@ -159,6 +159,13 @@ impl<S> TypedHyperContext<S> {
     }
 
     ///
+    /// Set the response status code
+    ///
+    pub fn status(&mut self, code: u32) {
+        self.status = code.try_into().unwrap();
+    }
+
+    ///
     /// Set the response `Content-Type`. A shortcode for
     ///
     /// ```ignore

--- a/thruster/src/core/context.rs
+++ b/thruster/src/core/context.rs
@@ -29,4 +29,7 @@ pub trait Context {
 
     /// remove is used to remove a header on the outgoing response.
     fn remove(&mut self, key: &str);
+
+    /// status sets the http status of the response
+    fn status(&mut self, status: u16);
 }

--- a/thruster/src/core/context.rs
+++ b/thruster/src/core/context.rs
@@ -31,5 +31,7 @@ pub trait Context {
     fn remove(&mut self, key: &str);
 
     /// status sets the http status of the response
-    fn status(&mut self, status: u16);
+    fn status(&mut self, _status: u16) {
+        warn!("status nothing by default, but is provided for backcompat. This will be removed in future releases.")
+    }
 }

--- a/thruster/src/core/errors.rs
+++ b/thruster/src/core/errors.rs
@@ -4,7 +4,7 @@ use std::error::Error as StdError;
 pub struct ThrusterError<C> {
     pub context: C,
     pub message: String,
-    pub status: u32,
+    pub status: u16,
     pub cause: Option<Box<dyn StdError>>,
 }
 
@@ -13,7 +13,9 @@ pub trait Error<C> {
 }
 
 impl<C: Context> Error<C> for ThrusterError<C> {
-    fn build_context(self) -> C {
+    fn build_context(mut self) -> C {
+        self.context.status(self.status);
+        self.context.set_body(self.message.as_bytes().into());
         self.context
     }
 }

--- a/thruster/src/core/errors.rs
+++ b/thruster/src/core/errors.rs
@@ -4,7 +4,7 @@ use std::error::Error as StdError;
 pub struct ThrusterError<C> {
     pub context: C,
     pub message: String,
-    pub status: u16,
+    pub status: u32,
     pub cause: Option<Box<dyn StdError>>,
 }
 
@@ -14,7 +14,7 @@ pub trait Error<C> {
 
 impl<C: Context> Error<C> for ThrusterError<C> {
     fn build_context(mut self) -> C {
-        self.context.status(self.status);
+        self.context.status(self.status as u16);
         self.context.set_body(self.message.as_bytes().into());
         self.context
     }


### PR DESCRIPTION
Needed to make it so setting the status code of an error actually set the status of the context. In order to do this, I added the status method into the Context trait. This will precipitate a minor version release as it's a breaking change.