### PR TITLE
bug: Fix basic context header setting

### DIFF
--- a/thruster/src/context/basic_context.rs
+++ b/thruster/src/context/basic_context.rs
@@ -151,6 +151,10 @@ impl Context for BasicContext {
     fn get_response(mut self) -> Self::Response {
         self.response.status_code(self.status, "");
 
+        for (key, value) in self.headers {
+            self.response.header(&key, &value);
+        }
+
         self.response
     }
 


### PR DESCRIPTION
As found on reddit, it looks like we were too aggressive cleaning up the response on `BasicContext`. We dropped the headers being set on the response! This should fix that.