### PR TITLE
bug: Add mitigation for slowloris attacks

### DIFF
--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -83,7 +83,10 @@ path = "src/integration_async_tests.rs"
 # path = "src/parser/tree.rs"
 
 [features]
-default = []
+default = [
+  "hyper_server",
+  "tls"
+]
 actix_server = [
   "actix-web",
   "actix-service",

--- a/thruster/examples/hyper_most_basic.rs
+++ b/thruster/examples/hyper_most_basic.rs
@@ -20,6 +20,7 @@ fn main() {
     info!("Starting server...");
 
     let mut app = App::<HyperRequest, Ctx, ()>::create(generate_context, ());
+    app.connection_timeout = 5000;
     app.get("/plaintext", m![plaintext]);
 
     let server = HyperServer::new(app);

--- a/thruster/src/app/thruster_app.rs
+++ b/thruster/src/app/thruster_app.rs
@@ -75,6 +75,8 @@ pub struct App<R: ThrusterRequest, T: 'static + Context + Clone + Send + Sync, S
     /// 404s.
     pub context_generator: fn(R, &S, &str) -> T,
     pub state: std::sync::Arc<S>,
+    /// The connection timeout for the app in milliseconds. Defaults to 3600000ms (1 hour)
+    pub connection_timeout: u64,
 }
 
 impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static + Send>
@@ -99,6 +101,7 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
             patch_root: Node::default(),
             context_generator: generate_context,
             state: std::sync::Arc::new(state),
+            connection_timeout: 3600000,
         }
     }
 

--- a/thruster/src/parser/tree.rs
+++ b/thruster/src/parser/tree.rs
@@ -399,8 +399,6 @@ impl<T: 'static + Context + Clone + Send> Node<T> {
     ) {
         let path_piece = path.next();
 
-        println!("Trying piece: {:#?}", path_piece);
-
         match path_piece {
             Some(path_piece) => {
                 match path_piece.chars().next() {

--- a/thruster/src/server/thruster_server.rs
+++ b/thruster/src/server/thruster_server.rs
@@ -14,8 +14,12 @@ pub trait ThrusterServer {
     where
         Self: Sized,
     {
-        tokio::runtime::Runtime::new()
-            .unwrap()
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime")
+            // tokio::runtime::Runtime::new()
+            //     .unwrap()
             .block_on(self.build(host, port))
     }
 }


### PR DESCRIPTION
Adds a potential timeout to hyper-based servers (now will default to one hour) in order to drop long running connections. This can be changed on the app by changing the  property, which is designated in milliseconds.