### PR TITLE
Middleware alias for middleware_fn

### DIFF
--- a/thruster-proc/src/lib.rs
+++ b/thruster-proc/src/lib.rs
@@ -78,6 +78,11 @@ pub fn async_middleware(items: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn middleware(attr: TokenStream, item: TokenStream) -> TokenStream {
+    middleware_fn(attr, item)
+}
+
+#[proc_macro_attribute]
 pub fn middleware_fn(attr: TokenStream, item: TokenStream) -> TokenStream {
     if let syn::Item::Fn(mut function_item) = syn::parse(item.clone()).unwrap() {
         let name = function_item.ident.clone();


### PR DESCRIPTION
Proc macro attribute alias for `#[middleware_fn]`.

```rs
#[middleware]
async fn alias(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
    let val = "Hello, World!";
    context.body(val);
    Ok(context)
}

#[middleware_fn]
async fn original(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
    let val = "Hello, World!";
    context.body(val);
    Ok(context)
}
```