### PR TITLE
Consuming app builder pattern

### DIFF
--- a/thruster/benches/app.rs
+++ b/thruster/benches/app.rs
@@ -3,8 +3,6 @@ extern crate criterion;
 
 use bytes::{BufMut, BytesMut};
 
-
-
 use criterion::Criterion;
 use thruster::middleware::query_params::query_params;
 use thruster::{

--- a/thruster/examples/actix_most_basic.rs
+++ b/thruster/examples/actix_most_basic.rs
@@ -17,8 +17,8 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<ActixRequest, Ctx, ()>::create(generate_context, ());
-    app.get("/plaintext", m![plaintext]);
+    let app =
+        App::<ActixRequest, Ctx, ()>::create(generate_context, ()).get("/plaintext", m![plaintext]);
 
     let server = ActixServer::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/examples/error_handling.rs
+++ b/thruster/examples/error_handling.rs
@@ -97,12 +97,10 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<Request, Ctx, ()>::new_basic();
-
-    app.use_middleware("/", async_middleware!(Ctx, [json_error_handler]));
-
-    app.get("/error", async_middleware!(Ctx, [error]));
-    app.set404(async_middleware!(Ctx, [four_oh_four]));
+    let app = App::<Request, Ctx, ()>::new_basic()
+        .use_middleware("/", async_middleware!(Ctx, [json_error_handler]))
+        .get("/error", async_middleware!(Ctx, [error]))
+        .set404(async_middleware!(Ctx, [four_oh_four]));
 
     let server = Server::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/examples/fast_homegrown.rs
+++ b/thruster/examples/fast_homegrown.rs
@@ -3,8 +3,6 @@ use thruster::{async_middleware, middleware_fn};
 use thruster::{App, BasicContext as Ctx, Request, Server, ThrusterServer};
 use thruster::{MiddlewareNext, MiddlewareResult};
 
-// use thruster::m;
-
 #[middleware_fn]
 async fn plaintext(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
     let val = "Hello, World!";
@@ -16,13 +14,8 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<Request, Ctx, ()>::new_basic();
-
-    app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
-    // app.get("/plaintext", {
-    //     use thruster::m;
-    //     m![plaintext]
-    // });
+    let app =
+        App::<Request, Ctx, ()>::new_basic().get("/plaintext", async_middleware!(Ctx, [plaintext]));
 
     let server = Server::new(app);
     server.start_small_load_optimized("0.0.0.0", 4321);

--- a/thruster/examples/fast_hyper.rs
+++ b/thruster/examples/fast_hyper.rs
@@ -20,8 +20,8 @@ async fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<HyperRequest, Ctx, ()>::create(generate_context, ());
-    app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
+    let app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
+        .get("/plaintext", async_middleware!(Ctx, [plaintext]));
 
     let server = HyperServer::new(app);
     server.build("0.0.0.0", 4321).await;

--- a/thruster/examples/hello_world.rs
+++ b/thruster/examples/hello_world.rs
@@ -14,9 +14,7 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<Request, Ctx, ()>::new_basic();
-
-    app.get("/plaintext", m![plaintext]);
+    let app = App::<Request, Ctx, ()>::new_basic().get("/plaintext", m![plaintext]);
 
     let server = Server::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/examples/hyper_most_basic.rs
+++ b/thruster/examples/hyper_most_basic.rs
@@ -19,9 +19,10 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<HyperRequest, Ctx, ()>::create(generate_context, ());
+    let mut app =
+        App::<HyperRequest, Ctx, ()>::create(generate_context, ()).get("/plaintext", m![plaintext]);
+
     app.connection_timeout = 5000;
-    app.get("/plaintext", m![plaintext]);
 
     let server = HyperServer::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/examples/multiple_services.rs
+++ b/thruster/examples/multiple_services.rs
@@ -20,16 +20,14 @@ async fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<Request, Ctx, ()>::new_basic();
-
-    app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
+    let app =
+        App::<Request, Ctx, ()>::new_basic().get("/plaintext", async_middleware!(Ctx, [plaintext]));
 
     let server = Server::new(app);
     tokio::spawn(server.build("0.0.0.0", 4321));
 
-    let mut healthcheck = App::<Request, Ctx, ()>::new_basic();
-
-    healthcheck.get("/healthz", async_middleware!(Ctx, [noop]));
+    let healthcheck =
+        App::<Request, Ctx, ()>::new_basic().get("/healthz", async_middleware!(Ctx, [noop]));
 
     let healthcheck_server = Server::new(healthcheck);
     tokio::spawn(healthcheck_server.build("0.0.0.0", 8080));

--- a/thruster/examples/mutable_state.rs
+++ b/thruster/examples/mutable_state.rs
@@ -58,14 +58,14 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<HyperRequest, Ctx, ServerConfig>::create(
+    let app = App::<HyperRequest, Ctx, ServerConfig>::create(
         generate_context,
         ServerConfig {
             val: Arc::new(RwLock::new("original".to_string())),
         },
-    );
-    app.get("/set-value/:val", async_middleware!(Ctx, [state_setter]));
-    app.get("/get-value", async_middleware!(Ctx, [state_getter]));
+    )
+    .get("/set-value/:val", async_middleware!(Ctx, [state_setter]))
+    .get("/get-value", async_middleware!(Ctx, [state_getter]));
 
     let server = HyperServer::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/examples/nesting.rs
+++ b/thruster/examples/nesting.rs
@@ -26,13 +26,12 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<HyperRequest, Ctx, ()>::create(generate_context, ());
-    app.get("/plaintext", m![plaintext]);
+    let nested_app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
+        .get("/plaintext", m![nested_plaintext]);
 
-    let mut nested_app = App::<HyperRequest, Ctx, ()>::create(generate_context, ());
-    nested_app.get("/plaintext", m![nested_plaintext]);
-
-    app.use_sub_app("/nested", nested_app);
+    let app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
+        .get("/plaintext", m![plaintext])
+        .use_sub_app("/nested", nested_app);
 
     let server = HyperServer::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/examples/profiling.rs
+++ b/thruster/examples/profiling.rs
@@ -38,11 +38,9 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<Request, Ctx, ()>::new_basic();
-
-    // app.use_middleware("/", async_middleware!(Ctx, [profiling]));
-    app.get("/plaintext", m![profiling, plaintext]);
-    app.set404(m![test_fn_404]);
+    let app = App::<Request, Ctx, ()>::new_basic()
+        .get("/plaintext", m![profiling, plaintext])
+        .set404(m![test_fn_404]);
 
     let server = Server::new(app);
 

--- a/thruster/examples/unix_socket.rs
+++ b/thruster/examples/unix_socket.rs
@@ -19,8 +19,8 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<HyperRequest, Ctx, ()>::create(generate_context, ());
-    app.get("/plaintext", async_middleware!(Ctx, [plaintext]));
+    let app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
+        .get("/plaintext", async_middleware!(Ctx, [plaintext]));
 
     UnixHyperServer::new(app).start("/tmp/thruster.sock", 0);
 }

--- a/thruster/examples/using_state.rs
+++ b/thruster/examples/using_state.rs
@@ -41,14 +41,14 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let mut app = App::<HyperRequest, Ctx, ServerConfig>::create(
+    let app = App::<HyperRequest, Ctx, ServerConfig>::create(
         generate_context,
         ServerConfig {
             server_id: "some-test-id".to_string(),
         },
-    );
-    app.get("/a/:key1", async_middleware!(Ctx, [state_printer]));
-    app.get("/b/:key2", async_middleware!(Ctx, [state_printer]));
+    )
+    .get("/a/:key1", async_middleware!(Ctx, [state_printer]))
+    .get("/b/:key2", async_middleware!(Ctx, [state_printer]));
 
     let server = HyperServer::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/src/app/thruster_app.rs
+++ b/thruster/src/app/thruster_app.rs
@@ -146,66 +146,42 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
     }
 
     /// Add a route that responds to `GET`s to a given path
-    pub fn get(
-        mut self,
-        path: &str,
-        middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> Self {
+    pub fn get(mut self, path: &str, middlewares: MiddlewareTuple<ReturnValue<T>>) -> Self {
         self.get_root.add_value_at_path(path, middlewares);
 
         self
     }
 
     /// Add a route that responds to `OPTION`s to a given path
-    pub fn options(
-        mut self,
-        path: &str,
-        middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> Self {
+    pub fn options(mut self, path: &str, middlewares: MiddlewareTuple<ReturnValue<T>>) -> Self {
         self.options_root.add_value_at_path(path, middlewares);
 
         self
     }
 
     /// Add a route that responds to `POST`s to a given path
-    pub fn post(
-        mut self,
-        path: &str,
-        middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> Self {
+    pub fn post(mut self, path: &str, middlewares: MiddlewareTuple<ReturnValue<T>>) -> Self {
         self.post_root.add_value_at_path(path, middlewares);
 
         self
     }
 
     /// Add a route that responds to `PUT`s to a given path
-    pub fn put(
-        mut self,
-        path: &str,
-        middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> Self {
+    pub fn put(mut self, path: &str, middlewares: MiddlewareTuple<ReturnValue<T>>) -> Self {
         self.put_root.add_value_at_path(path, middlewares);
 
         self
     }
 
     /// Add a route that responds to `DELETE`s to a given path
-    pub fn delete(
-        mut self,
-        path: &str,
-        middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> Self {
+    pub fn delete(mut self, path: &str, middlewares: MiddlewareTuple<ReturnValue<T>>) -> Self {
         self.delete_root.add_value_at_path(path, middlewares);
 
         self
     }
 
     /// Add a route that responds to `PATCH`s to a given path
-    pub fn patch(
-        mut self,
-        path: &str,
-        middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> Self {
+    pub fn patch(mut self, path: &str, middlewares: MiddlewareTuple<ReturnValue<T>>) -> Self {
         self.patch_root.add_value_at_path(path, middlewares);
 
         self

--- a/thruster/src/app/thruster_app.rs
+++ b/thruster/src/app/thruster_app.rs
@@ -91,7 +91,7 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
 
     /// Create a new app with the given context generator. The app does not begin listening until start
     /// is called.
-    pub fn create(generate_context: fn(R, &S, &str) -> T, state: S) -> App<R, T, S> {
+    pub fn create(generate_context: fn(R, &S, &str) -> T, state: S) -> Self {
         App {
             delete_root: Node::default(),
             get_root: Node::default(),
@@ -108,10 +108,10 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
     /// Add method-agnostic middleware for a route. This is useful for applying headers, logging, and
     /// anything else that might not be sensitive to the HTTP method for the endpoint.
     pub fn use_middleware(
-        &mut self,
+        mut self,
         path: &str,
         middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> &mut App<R, T, S>
+    ) -> Self
     where
         T: Clone,
     {
@@ -134,7 +134,7 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
     /// Add an app as a predetermined set of routes and middleware. Will prefix whatever string is passed
     /// in to all of the routes. This is a main feature of Thruster, as it allows projects to be extermely
     /// modular and composeable in nature.
-    pub fn use_sub_app(&mut self, prefix: &str, app: App<R, T, S>) -> &mut App<R, T, S> {
+    pub fn use_sub_app(mut self, prefix: &str, app: App<R, T, S>) -> Self {
         self.get_root.add_node_at_path(prefix, app.get_root);
         self.options_root.add_node_at_path(prefix, app.options_root);
         self.post_root.add_node_at_path(prefix, app.post_root);
@@ -147,10 +147,10 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
 
     /// Add a route that responds to `GET`s to a given path
     pub fn get(
-        &mut self,
+        mut self,
         path: &str,
         middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> &mut App<R, T, S> {
+    ) -> Self {
         self.get_root.add_value_at_path(path, middlewares);
 
         self
@@ -158,10 +158,10 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
 
     /// Add a route that responds to `OPTION`s to a given path
     pub fn options(
-        &mut self,
+        mut self,
         path: &str,
         middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> &mut App<R, T, S> {
+    ) -> Self {
         self.options_root.add_value_at_path(path, middlewares);
 
         self
@@ -169,10 +169,10 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
 
     /// Add a route that responds to `POST`s to a given path
     pub fn post(
-        &mut self,
+        mut self,
         path: &str,
         middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> &mut App<R, T, S> {
+    ) -> Self {
         self.post_root.add_value_at_path(path, middlewares);
 
         self
@@ -180,10 +180,10 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
 
     /// Add a route that responds to `PUT`s to a given path
     pub fn put(
-        &mut self,
+        mut self,
         path: &str,
         middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> &mut App<R, T, S> {
+    ) -> Self {
         self.put_root.add_value_at_path(path, middlewares);
 
         self
@@ -191,10 +191,10 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
 
     /// Add a route that responds to `DELETE`s to a given path
     pub fn delete(
-        &mut self,
+        mut self,
         path: &str,
         middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> &mut App<R, T, S> {
+    ) -> Self {
         self.delete_root.add_value_at_path(path, middlewares);
 
         self
@@ -202,10 +202,10 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
 
     /// Add a route that responds to `PATCH`s to a given path
     pub fn patch(
-        &mut self,
+        mut self,
         path: &str,
         middlewares: MiddlewareTuple<ReturnValue<T>>,
-    ) -> &mut App<R, T, S> {
+    ) -> Self {
         self.patch_root.add_value_at_path(path, middlewares);
 
         self
@@ -214,7 +214,7 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
     /// Sets the middleware if no route is successfully matched. Note, that due to type restrictions,
     /// we Context needs to implement Clone in order to call this function, even though _clone will
     /// never be called._
-    pub fn set404(&mut self, middlewares: MiddlewareTuple<ReturnValue<T>>) -> &mut App<R, T, S>
+    pub fn set404(mut self, middlewares: MiddlewareTuple<ReturnValue<T>>) -> Self
     where
         T: Clone,
     {
@@ -232,7 +232,7 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
 
     /// Sets whether this app router uses strict mode for route parsing or not. Strict mode considers
     /// `/a` to be distinct from `/a/`.
-    pub fn set_strict_mode(&mut self, strict_mode: bool) -> &mut App<R, T, S>
+    pub fn set_strict_mode(mut self, strict_mode: bool) -> Self
     where
         T: Clone,
     {

--- a/thruster/src/context/basic_context.rs
+++ b/thruster/src/context/basic_context.rs
@@ -211,7 +211,8 @@ impl HasCookies for BasicContext {
     fn get_cookies(&self) -> Vec<String> {
         self.request
             .headers()
-            .get("cookie").cloned()
+            .get("cookie")
+            .cloned()
             .unwrap_or_else(std::vec::Vec::new)
     }
 

--- a/thruster/src/core/middleware.rs
+++ b/thruster/src/core/middleware.rs
@@ -2,8 +2,6 @@ use crate::core::errors::ThrusterError;
 use crate::ReusableBoxFuture;
 use std::boxed::Box;
 
-
-
 pub type MiddlewareResult<C> = Result<C, ThrusterError<C>>;
 pub type MiddlewareReturnValue<C> = ReusableBoxFuture<MiddlewareResult<C>>;
 pub type MiddlewareNext<C> = Box<dyn FnOnce(C) -> ReusableBoxFuture<MiddlewareResult<C>> + Send>;

--- a/thruster/src/core/request.rs
+++ b/thruster/src/core/request.rs
@@ -113,7 +113,6 @@ impl Request {
                 }
                 None => {
                     header_map.insert(k, vec![v]);
-                    
                 }
             };
         }


### PR DESCRIPTION
Use the consuming builder pattern to make the construction of apps more intuitive.

New
```rs
let app = App::<Request, Ctx, ()>::new_basic().get("/plaintext", m![plaintext]);

let server = Server::new(app);
server.start("0.0.0.0", 4321);
```

Old
```rs
    let mut app = App::<Request, Ctx, ()>::new_basic();
    app.get("/plaintext", m![plaintext]);

    let server = Server::new(app);
    server.start("0.0.0.0", 4321);
```
