### PR TITLE
feat: Add request with params trait

### DIFF
--- a/thruster-proc/Cargo.toml
+++ b/thruster-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-proc"
-version = "1.1.16"
+version = "1.2.1"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The proc macros behind the thruster web framework"
 readme = "README.md"

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "1.1.16"
+version = "1.2.1"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "../README.md"

--- a/thruster/examples/middleware.rs
+++ b/thruster/examples/middleware.rs
@@ -1,0 +1,31 @@
+use hyper::Body;
+use log::info;
+use thruster::context::basic_hyper_context::{
+    generate_context, BasicHyperContext as Ctx, HyperRequest,
+};
+use thruster::hyper_server::HyperServer;
+use thruster::middleware::cors::cors;
+use thruster::{m, middleware_fn};
+use thruster::{App, ThrusterServer};
+use thruster::{MiddlewareNext, MiddlewareResult};
+
+#[middleware_fn]
+async fn plaintext(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+    let val = "Hello, World!";
+    context.body = Body::from(val);
+    Ok(context)
+}
+
+fn main() {
+    env_logger::init();
+    info!("Starting server...");
+
+    let mut app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
+        .use_middleware("/", m![cors])
+        .get("/plaintext", m![plaintext]);
+
+    app.connection_timeout = 5000;
+
+    let server = HyperServer::new(app);
+    server.start("0.0.0.0", 4321);
+}

--- a/thruster/examples/mutable_state.rs
+++ b/thruster/examples/mutable_state.rs
@@ -35,12 +35,14 @@ async fn state_setter(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> Middlewar
     let mut latest_value = latest_value.write().unwrap();
     context.body = Body::from(format!("last value: {}", latest_value));
     *latest_value = context
-        .params
+        .hyper_request
         .as_ref()
         .unwrap()
+        .params
         .get("val")
         .unwrap()
-        .to_string();
+        .param
+        .clone();
 
     Ok(context)
 }

--- a/thruster/src/app/thruster_app.rs
+++ b/thruster/src/app/thruster_app.rs
@@ -1,4 +1,4 @@
-use crate::ReusableBoxFuture;
+use crate::{RequestWithParams, ReusableBoxFuture};
 use futures::FutureExt;
 
 use std::io;
@@ -254,7 +254,10 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
     pub fn match_and_resolve<'m>(
         &'m self,
         request: R,
-    ) -> ReusableBoxFuture<Result<T::Response, io::Error>> {
+    ) -> ReusableBoxFuture<Result<T::Response, io::Error>>
+    where
+        R: RequestWithParams,
+    {
         let method = request.method();
         let path = request.path();
 

--- a/thruster/src/context/actix_request.rs
+++ b/thruster/src/context/actix_request.rs
@@ -2,17 +2,18 @@ use actix_web::http::HeaderMap;
 use actix_web::web::{BytesMut, Payload};
 use actix_web::HttpRequest;
 use futures::StreamExt;
-use std::collections::HashMap;
 use std::net::IpAddr;
 
 use crate::core::request::ThrusterRequest;
+use crate::parser::tree::Params;
+use crate::RequestWithParams;
 
 pub struct ActixRequest {
     pub path: String,
     pub method: String,
     pub headers: HeaderMap,
     pub payload: Vec<u8>,
-    pub params: Option<HashMap<String, String>>,
+    pub params: Params,
     pub ip: Option<IpAddr>,
 }
 
@@ -32,7 +33,7 @@ impl ActixRequest {
             method,
             payload: bytes.to_vec(),
             headers,
-            params: None,
+            params: Params::default(),
             ip: None,
         }
     }
@@ -45,5 +46,15 @@ impl ThrusterRequest for ActixRequest {
 
     fn path(&self) -> String {
         self.path.to_string()
+    }
+}
+
+impl RequestWithParams for ActixRequest {
+    fn set_params(&mut self, params: Params) {
+        self.params = params;
+    }
+
+    fn get_params<'a>(&'a self) -> &'a Params {
+        &self.params
     }
 }

--- a/thruster/src/context/basic_actix_context.rs
+++ b/thruster/src/context/basic_actix_context.rs
@@ -50,7 +50,6 @@ impl CookieOptions {
 pub struct BasicActixContext {
     pub query_params: HashMap<String, String>,
     pub status: u16,
-    pub params: Option<HashMap<String, String>>,
     pub actix_request: Option<ActixRequest>,
     response_body: Bytes,
     headers: HeaderMap,
@@ -61,7 +60,6 @@ impl Default for BasicActixContext {
         BasicActixContext {
             query_params: HashMap::default(),
             status: 0,
-            params: None,
             actix_request: None,
             response_body: Bytes::new(),
             headers: HeaderMap::new(),
@@ -79,14 +77,12 @@ impl Clone for BasicActixContext {
 const SERVER_HEADER_NAME: HeaderName = SERVER;
 impl BasicActixContext {
     pub fn new(req: ActixRequest) -> BasicActixContext {
-        let params = req.params.clone();
         let mut headers = HeaderMap::new();
         headers.insert(SERVER_HEADER_NAME, HeaderValue::from_static("thruster"));
 
         BasicActixContext {
             query_params: HashMap::new(),
             status: 200,
-            params,
             actix_request: Some(req),
             response_body: Bytes::new(),
             headers,
@@ -113,7 +109,6 @@ impl BasicActixContext {
             BasicActixContext {
                 query_params: self.query_params,
                 status: self.status,
-                params: self.params,
                 actix_request: None,
                 response_body: Bytes::new(),
                 headers: self.headers,

--- a/thruster/src/context/basic_hyper_context.rs
+++ b/thruster/src/context/basic_hyper_context.rs
@@ -51,7 +51,6 @@ pub struct BasicHyperContext {
     pub body: Body,
     pub query_params: HashMap<String, String>,
     pub status: u16,
-    pub params: Option<HashMap<String, String>>,
     pub hyper_request: Option<HyperRequest>,
     request_body: Option<Body>,
     request_parts: Option<Parts>,
@@ -65,7 +64,6 @@ impl Default for BasicHyperContext {
             body: Default::default(),
             query_params: Default::default(),
             status: 200,
-            params: Default::default(),
             hyper_request: Default::default(),
             request_body: Default::default(),
             request_parts: Default::default(),
@@ -85,7 +83,6 @@ impl Clone for BasicHyperContext {
 const SERVER_HEADER_NAME: HeaderName = SERVER;
 impl BasicHyperContext {
     pub fn new(req: HyperRequest) -> BasicHyperContext {
-        let params = req.params.clone();
         let mut headers = HeaderMap::new();
         headers.insert(SERVER_HEADER_NAME, HeaderValue::from_static("thruster"));
 
@@ -93,7 +90,6 @@ impl BasicHyperContext {
             body: Body::empty(),
             query_params: HashMap::new(),
             status: 200,
-            params,
             hyper_request: Some(req),
             request_body: None,
             request_parts: None,
@@ -132,7 +128,6 @@ impl BasicHyperContext {
                 body: ctx.body,
                 query_params: ctx.query_params,
                 status: ctx.status,
-                params: ctx.params,
                 hyper_request: ctx.hyper_request,
                 request_body: Some(Body::empty()),
                 request_parts: ctx.request_parts,
@@ -158,7 +153,6 @@ impl BasicHyperContext {
             body: self.body,
             query_params: self.query_params,
             status: self.status,
-            params: hyper_request.params,
             hyper_request: None,
             request_body: Some(body),
             request_parts: Some(parts),

--- a/thruster/src/context/hyper_request.rs
+++ b/thruster/src/context/hyper_request.rs
@@ -1,7 +1,9 @@
 use http::request::Parts;
 use hyper::{Body, Request};
-use std::collections::HashMap;
 use std::net::IpAddr;
+
+use crate::parser::tree::Params;
+use crate::RequestWithParams;
 
 // use crate::core::request::RequestWithParams;
 // use crate::parser::tree::Params;
@@ -10,7 +12,7 @@ pub struct HyperRequest {
     pub request: Request<Body>,
     pub parts: Option<Parts>,
     pub body: Option<Body>,
-    pub params: Option<HashMap<String, String>>,
+    pub params: Params,
     pub ip: Option<IpAddr>,
 }
 
@@ -20,7 +22,7 @@ impl HyperRequest {
             request,
             parts: None,
             body: None,
-            params: None,
+            params: Params::default(),
             ip: None,
         }
     }
@@ -29,5 +31,15 @@ impl HyperRequest {
 impl Default for HyperRequest {
     fn default() -> Self {
         HyperRequest::new(Request::default())
+    }
+}
+
+impl RequestWithParams for HyperRequest {
+    fn set_params(&mut self, params: Params) {
+        self.params = params;
+    }
+
+    fn get_params<'a>(&'a self) -> &'a Params {
+        &self.params
     }
 }

--- a/thruster/src/context/typed_hyper_context.rs
+++ b/thruster/src/context/typed_hyper_context.rs
@@ -18,7 +18,6 @@ pub struct TypedHyperContext<S: 'static + Send> {
     pub query_params: HashMap<String, String>,
     pub status: u16,
     pub headers: HeaderMap,
-    pub params: Option<HashMap<String, String>>,
     pub hyper_request: Option<HyperRequest>,
     pub extra: S,
     pub cookies: HashMap<String, Cookie>,
@@ -34,7 +33,6 @@ impl<S: 'static + Send + Default> Default for TypedHyperContext<S> {
             query_params: Default::default(),
             status: 200,
             headers: Default::default(),
-            params: Default::default(),
             hyper_request: Default::default(),
             extra: S::default(),
             cookies: Default::default(),
@@ -53,13 +51,11 @@ impl<S: 'static + Send> Clone for TypedHyperContext<S> {
 
 impl<S: 'static + Send> TypedHyperContext<S> {
     pub fn new(req: HyperRequest, extra: S) -> TypedHyperContext<S> {
-        let params = req.params.clone();
         let mut ctx = TypedHyperContext {
             body: Body::empty(),
             query_params: HashMap::new(),
             headers: HeaderMap::new(),
             status: 200,
-            params,
             hyper_request: Some(req),
             request_body: None,
             request_parts: None,
@@ -74,13 +70,11 @@ impl<S: 'static + Send> TypedHyperContext<S> {
     }
 
     pub fn new_without_request(extra: S) -> TypedHyperContext<S> {
-        let params = None;
         let mut ctx = TypedHyperContext {
             body: Body::empty(),
             query_params: HashMap::new(),
             headers: HeaderMap::new(),
             status: 200,
-            params,
             hyper_request: None,
             request_body: None,
             request_parts: None,
@@ -125,7 +119,6 @@ impl<S: 'static + Send> TypedHyperContext<S> {
                 query_params: ctx.query_params,
                 headers: ctx.headers,
                 status: ctx.status,
-                params: ctx.params,
                 hyper_request: ctx.hyper_request,
                 request_body: Some(Body::empty()),
                 request_parts: ctx.request_parts,
@@ -152,7 +145,6 @@ impl<S: 'static + Send> TypedHyperContext<S> {
                     query_params: self.query_params,
                     headers: self.headers,
                     status: self.status,
-                    params: hyper_request.params,
                     hyper_request: None,
                     request_body: Some(body),
                     request_parts: Some(parts),

--- a/thruster/src/core/request.rs
+++ b/thruster/src/core/request.rs
@@ -6,6 +6,7 @@ use std::{fmt, io, str};
 
 pub trait RequestWithParams {
     fn set_params(&mut self, _: Params);
+    fn get_params<'a>(&'a self) -> &'a Params;
 }
 
 pub trait ThrusterRequest {


### PR DESCRIPTION
In order to utilize match_and_resolve, which is helpful for limiting lifetimes, we need to have a better way to get and set params on the request. This adds a required trait to use the method, which will potentially break some implementations.