### PR TITLE
bug: Fix query parameter handling

### DIFF
--- a/thruster-proc/Cargo.toml
+++ b/thruster-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-proc"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The proc macros behind the thruster web framework"
 readme = "README.md"

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "../README.md"

--- a/thruster/src/context/hyper_request.rs
+++ b/thruster/src/context/hyper_request.rs
@@ -5,9 +5,6 @@ use std::net::IpAddr;
 use crate::parser::tree::Params;
 use crate::RequestWithParams;
 
-// use crate::core::request::RequestWithParams;
-// use crate::parser::tree::Params;
-
 pub struct HyperRequest {
     pub request: Request<Body>,
     pub parts: Option<Parts>,


### PR DESCRIPTION
Query parameters were not being trimmed during route matching, so any request that had query parameters on it was not being matched unless it ended with a wildcard.