### PR TITLE
feat: Add more examples and cleanup

### DIFF
--- a/thruster-proc/Cargo.toml
+++ b/thruster-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-proc"
-version = "1.2.6"
+version = "1.3.0"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The proc macros behind the thruster web framework"
 readme = "README.md"

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "1.2.6"
+version = "1.3.0"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "../README.md"
@@ -12,12 +12,28 @@ repository = "https://github.com/trezm/thruster"
 edition = "2018"
 
 [[example]]
+name = "custom_middleware_with_auth"
+required-features = ["hyper_server"]
+
+[[example]]
 name = "hello_world"
 required-features = []
 
 [[example]]
+name = "headers"
+required-features = ["hyper_server"]
+
+[[example]]
 name = "profiling"
 required-features = []
+
+[[example]]
+name = "query_params"
+required-features = ["hyper_server"]
+
+[[example]]
+name = "route_params"
+required-features = ["hyper_server"]
 
 [[example]]
 name = "most_basic_ssl"
@@ -29,6 +45,10 @@ required-features = []
 
 [[example]]
 name = "hyper_most_basic"
+required-features = ["hyper_server"]
+
+[[example]]
+name = "json"
 required-features = ["hyper_server"]
 
 [[example]]

--- a/thruster/examples/custom_middleware_with_auth.rs
+++ b/thruster/examples/custom_middleware_with_auth.rs
@@ -21,12 +21,12 @@ struct User {
 
 #[derive(Default)]
 struct ServerConfig {
-    pool: Arc<Mutex<HashMap<String, User>>>,
+    fake_db: Arc<Mutex<HashMap<String, User>>>,
 }
 
 #[derive(Default)]
 struct RequestConfig {
-    pool: Arc<Mutex<HashMap<String, User>>>,
+    fake_db: Arc<Mutex<HashMap<String, User>>>,
     user: Option<User>,
 }
 
@@ -34,7 +34,7 @@ fn generate_context(request: HyperRequest, state: &ServerConfig, _path: &str) ->
     Ctx::new(
         request,
         RequestConfig {
-            pool: state.pool.clone(),
+            fake_db: state.fake_db.clone(),
             user: None,
         },
     )
@@ -51,7 +51,7 @@ async fn hello(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult
 
 #[middleware_fn]
 async fn authenticate(mut context: Ctx, next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
-    let db = context.extra.pool.clone();
+    let db = context.extra.fake_db.clone();
 
     let session_header = context
         .get_header("Session-Token")
@@ -76,7 +76,7 @@ fn main() {
     let app = App::<HyperRequest, Ctx, ServerConfig>::create(
         generate_context,
         ServerConfig {
-            pool: Arc::new(Mutex::new(HashMap::from([
+            fake_db: Arc::new(Mutex::new(HashMap::from([
                 (
                     "lukes-secret-session-token".to_string(),
                     User {

--- a/thruster/examples/custom_middleware_with_auth.rs
+++ b/thruster/examples/custom_middleware_with_auth.rs
@@ -1,0 +1,101 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use log::info;
+use thruster::{
+    context::typed_hyper_context::TypedHyperContext,
+    errors::{ErrorSet, ThrusterError},
+    hyper_server::HyperServer,
+    m,
+    middleware::cookies::HasCookies,
+    middleware_fn, App, HyperRequest, MiddlewareNext, MiddlewareResult, ThrusterServer,
+};
+use tokio::sync::Mutex;
+
+type Ctx = TypedHyperContext<RequestConfig>;
+
+struct User {
+    first: String,
+    last: String,
+}
+
+#[derive(Default)]
+struct ServerConfig {
+    pool: Arc<Mutex<HashMap<String, User>>>,
+}
+
+#[derive(Default)]
+struct RequestConfig {
+    pool: Arc<Mutex<HashMap<String, User>>>,
+    user: Option<User>,
+}
+
+fn generate_context(request: HyperRequest, state: &ServerConfig, _path: &str) -> Ctx {
+    Ctx::new(
+        request,
+        RequestConfig {
+            pool: state.pool.clone(),
+            user: None,
+        },
+    )
+}
+
+#[middleware_fn]
+async fn hello(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+    let user = context.extra.user.as_ref().unwrap();
+
+    context.body(&format!("Hello, {} {}", user.first, user.last));
+
+    Ok(context)
+}
+
+#[middleware_fn]
+async fn authenticate(mut context: Ctx, next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+    let db = context.extra.pool.clone();
+
+    let session_header = context
+        .get_header("Session-Token")
+        .pop()
+        .unwrap_or_default();
+
+    let user = db.lock().await.remove(&session_header);
+
+    match user {
+        Some(user) => {
+            context.extra.user = Some(user);
+            next(context).await
+        }
+        None => Err(ThrusterError::unauthorized_error(context)),
+    }
+}
+
+fn main() {
+    env_logger::init();
+    info!("Starting server...");
+
+    let app = App::<HyperRequest, Ctx, ServerConfig>::create(
+        generate_context,
+        ServerConfig {
+            pool: Arc::new(Mutex::new(HashMap::from([
+                (
+                    "lukes-secret-session-token".to_string(),
+                    User {
+                        first: "Luke".to_string(),
+                        last: "Skywalker".to_string(),
+                    },
+                ),
+                (
+                    "vaders-secret-session-token".to_string(),
+                    User {
+                        first: "Anakin".to_string(),
+                        last: "Skywalker".to_string(),
+                    },
+                ),
+            ]))),
+        },
+    )
+    .get("/hello", m![authenticate, hello]);
+
+    let server = HyperServer::new(app);
+    server.start("0.0.0.0", 4321);
+}

--- a/thruster/examples/fast_homegrown.rs
+++ b/thruster/examples/fast_homegrown.rs
@@ -15,7 +15,7 @@ fn main() {
     info!("Starting server...");
 
     let app =
-        App::<Request, Ctx, ()>::new_basic().get("/plaintext", m!(Ctx, [plaintext]));
+        App::<Request, Ctx, ()>::new_basic().get("/plaintext", m![plaintext]);
 
     let server = Server::new(app);
     server.start_small_load_optimized("0.0.0.0", 4321);

--- a/thruster/examples/fast_hyper.rs
+++ b/thruster/examples/fast_hyper.rs
@@ -20,8 +20,8 @@ async fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
-        .get("/plaintext", m!(Ctx, [plaintext]));
+    let app =
+        App::<HyperRequest, Ctx, ()>::create(generate_context, ()).get("/plaintext", m![plaintext]);
 
     let server = HyperServer::new(app);
     server.build("0.0.0.0", 4321).await;

--- a/thruster/examples/grpc/src/main.rs
+++ b/thruster/examples/grpc/src/main.rs
@@ -74,7 +74,7 @@
 //         App::<HyperRequest, Ctx, MyGreeter>::create(generate_context, MyGreeter::default());
 //     app.post(
 //         "/helloworld.Greeter/SayHello",
-//         m!(Ctx, [rpc]),
+//         m![rpc],
 //     );
 
 //     let server = HyperServer::new(app);

--- a/thruster/examples/headers.rs
+++ b/thruster/examples/headers.rs
@@ -15,7 +15,7 @@ async fn echo_header(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> Middleware
     context.body = Body::from(format!(
         "Hello, {}",
         context
-            .get_req_header("Custom-Header")
+            .req_header("Custom-Header")
             .unwrap_or("No 'Custom-Header' present")
     ));
 

--- a/thruster/examples/headers.rs
+++ b/thruster/examples/headers.rs
@@ -1,0 +1,36 @@
+use hyper::Body;
+use log::info;
+use thruster::{
+    context::{
+        basic_hyper_context::{generate_context, BasicHyperContext as Ctx, HyperRequest},
+        context_ext::ContextExt,
+    },
+    hyper_server::HyperServer,
+    m, middleware_fn, App, Context, MiddlewareNext, MiddlewareResult, ThrusterServer,
+};
+
+#[middleware_fn]
+async fn echo_header(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+    context.set("Content-Type", "text/plain");
+    context.body = Body::from(format!(
+        "Hello, {}",
+        context
+            .get_req_header("Custom-Header")
+            .unwrap_or("No 'Custom-Header' present")
+    ));
+
+    Ok(context)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    info!("Starting server...");
+
+    HyperServer::new(
+        App::<HyperRequest, Ctx, ()>::create(generate_context, ())
+            .post("/echo/:name", m![echo_header]),
+    )
+    .build("0.0.0.0", 4321)
+    .await;
+}

--- a/thruster/examples/hyper_most_basic_ssl/main.rs
+++ b/thruster/examples/hyper_most_basic_ssl/main.rs
@@ -26,8 +26,8 @@ fn main() {
     info!("Starting server...");
 
     let app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
-        .get("/plaintext", m!(Ctx, [plaintext]))
-        .set404(m!(Ctx, [test_fn_404]));
+        .get("/plaintext", m![plaintext])
+        .set404(m![test_fn_404]);
 
     let mut server = SSLHyperServer::new(app);
     server.cert(include_bytes!("./cert.pem").to_vec());

--- a/thruster/examples/json.rs
+++ b/thruster/examples/json.rs
@@ -1,0 +1,46 @@
+use log::info;
+use serde::{Deserialize, Serialize};
+use thruster::{
+    context::{
+        basic_hyper_context::{generate_context, BasicHyperContext as Ctx, HyperRequest},
+        context_ext::ContextExt,
+    },
+    errors::ThrusterError,
+    hyper_server::HyperServer,
+    m, middleware_fn, App, MiddlewareNext, MiddlewareResult, ThrusterServer,
+};
+
+#[derive(Deserialize)]
+struct EchoJsonRequest {
+    name: String,
+}
+
+#[derive(Serialize)]
+struct EchoJsonResponse {
+    message: String,
+}
+
+#[middleware_fn]
+async fn echo_json(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+    let body: EchoJsonRequest = context.get_json::<EchoJsonRequest>().await.map_err(|e| {
+        let e: ThrusterError<Ctx> = e.into();
+        e
+    })?;
+    context.json(&EchoJsonResponse {
+        message: format!("Hello, {}", body.name),
+    })?;
+
+    Ok(context)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    info!("Starting server...");
+
+    HyperServer::new(
+        App::<HyperRequest, Ctx, ()>::create(generate_context, ()).post("/json", m![echo_json]),
+    )
+    .build("0.0.0.0", 4321)
+    .await;
+}

--- a/thruster/examples/middleware.rs
+++ b/thruster/examples/middleware.rs
@@ -21,7 +21,7 @@ fn main() {
     info!("Starting server...");
 
     let mut app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
-        .use_middleware("/", m![cors])
+        .middleware("/", m![cors])
         .get("/plaintext", m![plaintext]);
 
     app.connection_timeout = 5000;

--- a/thruster/examples/most_basic_ssl/main.rs
+++ b/thruster/examples/most_basic_ssl/main.rs
@@ -23,8 +23,8 @@ fn main() {
     info!("Starting server...");
 
     let app = App::<Request, Ctx, ()>::new_basic()
-        .get("/plaintext", m!(Ctx, [plaintext]))
-        .set404(m!(Ctx, [test_fn_404]));
+        .get("/plaintext", m![plaintext])
+        .set404(m![test_fn_404]);
 
     let mut server = SSLServer::new(app);
     server.cert(include_bytes!("identity.p12").to_vec());

--- a/thruster/examples/multiple_services.rs
+++ b/thruster/examples/multiple_services.rs
@@ -20,14 +20,12 @@ async fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let app =
-        App::<Request, Ctx, ()>::new_basic().get("/plaintext", m!(Ctx, [plaintext]));
+    let app = App::<Request, Ctx, ()>::new_basic().get("/plaintext", m![plaintext]);
 
     let server = Server::new(app);
     tokio::spawn(server.build("0.0.0.0", 4321));
 
-    let healthcheck =
-        App::<Request, Ctx, ()>::new_basic().get("/healthz", m!(Ctx, [noop]));
+    let healthcheck = App::<Request, Ctx, ()>::new_basic().get("/healthz", m![noop]);
 
     let healthcheck_server = Server::new(healthcheck);
     tokio::spawn(healthcheck_server.build("0.0.0.0", 8080));

--- a/thruster/examples/mutable_state.rs
+++ b/thruster/examples/mutable_state.rs
@@ -66,8 +66,8 @@ fn main() {
             val: Arc::new(RwLock::new("original".to_string())),
         },
     )
-    .get("/set-value/:val", m!(Ctx, [state_setter]))
-    .get("/get-value", m!(Ctx, [state_getter]));
+    .get("/set-value/:val", m![state_setter])
+    .get("/get-value", m![state_getter]);
 
     let server = HyperServer::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/examples/nesting.rs
+++ b/thruster/examples/nesting.rs
@@ -31,7 +31,7 @@ fn main() {
 
     let app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
         .get("/plaintext", m![plaintext])
-        .use_sub_app("/nested", nested_app);
+        .router("/nested", nested_app);
 
     let server = HyperServer::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/examples/query_params.rs
+++ b/thruster/examples/query_params.rs
@@ -1,0 +1,37 @@
+use hyper::Body;
+use log::info;
+use thruster::{
+    context::basic_hyper_context::{generate_context, BasicHyperContext as Ctx, HyperRequest},
+    hyper_server::HyperServer,
+    m,
+    middleware::query_params::query_params,
+    middleware_fn, App, Context, MiddlewareNext, MiddlewareResult, ThrusterServer,
+};
+
+#[middleware_fn]
+async fn echo_query(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+    context.set("Content-Type", "text/plain");
+    context.body = Body::from(format!(
+        "Hello, {}",
+        context
+            .query_params
+            .get("name")
+            .map(Clone::clone)
+            .unwrap_or_else(|| "Unknown".to_string())
+    ));
+
+    Ok(context)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    info!("Starting server...");
+
+    HyperServer::new(
+        App::<HyperRequest, Ctx, ()>::create(generate_context, ())
+            .post("/query", m![query_params, echo_query]),
+    )
+    .build("0.0.0.0", 4321)
+    .await;
+}

--- a/thruster/examples/route_params.rs
+++ b/thruster/examples/route_params.rs
@@ -16,7 +16,7 @@ async fn echo_route_params(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> Midd
     context.body = Body::from(format!(
         "Hello, {}",
         context
-            .get_params()
+            .params()
             .get("name")
             .ok_or(ThrusterError::generic_error(Ctx::default()))?
             .param

--- a/thruster/examples/route_params.rs
+++ b/thruster/examples/route_params.rs
@@ -1,0 +1,39 @@
+use hyper::Body;
+use log::info;
+use thruster::{
+    context::{
+        basic_hyper_context::{generate_context, BasicHyperContext as Ctx, HyperRequest},
+        context_ext::ContextExt,
+    },
+    errors::{ErrorSet, ThrusterError},
+    hyper_server::HyperServer,
+    m, middleware_fn, App, Context, MiddlewareNext, MiddlewareResult, ThrusterServer,
+};
+
+#[middleware_fn]
+async fn echo_route_params(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
+    context.set("Content-Type", "text/plain");
+    context.body = Body::from(format!(
+        "Hello, {}",
+        context
+            .get_params()
+            .get("name")
+            .ok_or(ThrusterError::generic_error(Ctx::default()))?
+            .param
+    ));
+
+    Ok(context)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    info!("Starting server...");
+
+    HyperServer::new(
+        App::<HyperRequest, Ctx, ()>::create(generate_context, ())
+            .post("/echo/:name", m![echo_route_params]),
+    )
+    .build("0.0.0.0", 4321)
+    .await;
+}

--- a/thruster/examples/static_file/main.rs
+++ b/thruster/examples/static_file/main.rs
@@ -33,8 +33,8 @@ fn main() {
     info!("Starting server...");
 
     let app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
-        .get("/", m!(Ctx, [index]))
-        .get("/*", m!(Ctx, [file]));
+        .get("/", m![index])
+        .get("/*", m![file]);
 
     let server = HyperServer::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/examples/unix_socket.rs
+++ b/thruster/examples/unix_socket.rs
@@ -19,8 +19,8 @@ fn main() {
     env_logger::init();
     info!("Starting server...");
 
-    let app = App::<HyperRequest, Ctx, ()>::create(generate_context, ())
-        .get("/plaintext", m!(Ctx, [plaintext]));
+    let app =
+        App::<HyperRequest, Ctx, ()>::create(generate_context, ()).get("/plaintext", m![plaintext]);
 
     UnixHyperServer::new(app).start("/tmp/thruster.sock", 0);
 }

--- a/thruster/examples/using_state.rs
+++ b/thruster/examples/using_state.rs
@@ -47,8 +47,8 @@ fn main() {
             server_id: "some-test-id".to_string(),
         },
     )
-    .get("/a/:key1", m!(Ctx, [state_printer]))
-    .get("/b/:key2", m!(Ctx, [state_printer]));
+    .get("/a/:key1", m![state_printer])
+    .get("/b/:key2", m![state_printer]);
 
     let server = HyperServer::new(app);
     server.start("0.0.0.0", 4321);

--- a/thruster/src/app/thruster_app.rs
+++ b/thruster/src/app/thruster_app.rs
@@ -263,7 +263,6 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
         }
     }
 
-    // pub async fn match_and_resolve<'m>(&'m self, request: R) -> Result<T::Response, io::Error> {
     pub fn match_and_resolve<'m>(
         &'m self,
         mut request: R,

--- a/thruster/src/context/basic_actix_context.rs
+++ b/thruster/src/context/basic_actix_context.rs
@@ -98,7 +98,7 @@ impl BasicActixContext {
     ///
     /// Get the request body as a string
     ///
-    pub async fn get_body(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+    pub async fn body_string(&mut self) -> Result<String, Box<dyn std::error::Error>> {
         let request = self.actix_request.as_ref().unwrap();
 
         let results = String::from_utf8(request.payload.clone()).unwrap();

--- a/thruster/src/context/basic_actix_context.rs
+++ b/thruster/src/context/basic_actix_context.rs
@@ -3,7 +3,6 @@ use actix_web::http::{HeaderMap, HeaderName};
 use http::header::SERVER;
 use http::HeaderValue;
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::str;
 
 use crate::core::context::Context;
@@ -99,28 +98,12 @@ impl BasicActixContext {
     ///
     /// Get the request body as a string
     ///
-    pub async fn get_body(self) -> Result<(String, BasicActixContext), Box<dyn std::error::Error>> {
-        let request = self.actix_request.unwrap();
+    pub async fn get_body(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+        let request = self.actix_request.as_ref().unwrap();
 
-        let results = String::from_utf8(request.payload).unwrap();
+        let results = String::from_utf8(request.payload.clone()).unwrap();
 
-        Ok((
-            results,
-            BasicActixContext {
-                query_params: self.query_params,
-                status: self.status,
-                actix_request: None,
-                response_body: Bytes::new(),
-                headers: self.headers,
-            },
-        ))
-    }
-
-    ///
-    /// Set the response status code
-    ///
-    pub fn status(&mut self, code: u32) {
-        self.status = code.try_into().unwrap();
+        Ok(results)
     }
 
     ///
@@ -245,6 +228,10 @@ impl Context for BasicActixContext {
 
     fn remove(&mut self, key: &str) {
         self.headers.remove(key);
+    }
+
+    fn status(&mut self, code: u16) {
+        self.status = code;
     }
 }
 

--- a/thruster/src/context/basic_context.rs
+++ b/thruster/src/context/basic_context.rs
@@ -78,7 +78,7 @@ impl BasicContext {
         self
     }
 
-    pub fn get_body(&self) -> String {
+    pub fn body_string(&self) -> String {
         str::from_utf8(&self.response.response)
             .unwrap_or("")
             .to_owned()

--- a/thruster/src/context/basic_context.rs
+++ b/thruster/src/context/basic_context.rs
@@ -74,7 +74,7 @@ impl BasicContext {
     /// Set the response status code
     ///
     pub fn set_status(&mut self, code: u32) -> &mut BasicContext {
-        self.status(code);
+        self.status = code;
         self
     }
 
@@ -82,13 +82,6 @@ impl BasicContext {
         str::from_utf8(&self.response.response)
             .unwrap_or("")
             .to_owned()
-    }
-
-    ///
-    /// Set the response status code
-    ///
-    pub fn status(&mut self, code: u32) {
-        self.status = code;
     }
 
     ///
@@ -194,6 +187,10 @@ impl Context for BasicContext {
 
     fn remove(&mut self, key: &str) {
         self.headers.remove(key);
+    }
+
+    fn status(&mut self, code: u16) {
+        self.set_status(code as u32);
     }
 }
 

--- a/thruster/src/context/basic_hyper_context.rs
+++ b/thruster/src/context/basic_hyper_context.rs
@@ -110,7 +110,7 @@ impl BasicHyperContext {
     ///
     /// Get the body as a string
     ///
-    pub async fn get_body(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+    pub async fn body_string(&mut self) -> Result<String, Box<dyn std::error::Error>> {
         let body = self.request_body.take().unwrap_or_else(|| {
             self.into_owned_request();
             self.request_body.take().unwrap()
@@ -278,7 +278,7 @@ impl HasQueryParams for BasicHyperContext {
 
 #[async_trait]
 impl ContextExt for BasicHyperContext {
-    fn get_params(&self) -> &Params {
+    fn params(&self) -> &Params {
         self.hyper_request.as_ref().unwrap().get_params()
     }
 
@@ -299,7 +299,7 @@ impl ContextExt for BasicHyperContext {
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
     }
 
-    fn get_req_header<'a>(&'a self, header: &str) -> Option<&'a str> {
+    fn req_header<'a>(&'a self, header: &str) -> Option<&'a str> {
         self.parts()
             .headers
             .get(header)

--- a/thruster/src/context/context_ext.rs
+++ b/thruster/src/context/context_ext.rs
@@ -1,0 +1,20 @@
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::parser::tree::Params;
+
+#[async_trait]
+pub trait ContextExt {
+    /// Get route params, e.g. /users/:id
+    fn get_params<'a>(&'a self) -> &'a Params;
+
+    /// Set the response as JSON.
+    ///
+    /// This method both sets the Content-Type header as well as the body as JSON.
+    fn json<T: Serialize>(&mut self, body: &T) -> Result<(), Box<dyn std::error::Error>>;
+
+    /// Gets the request body as JSON.
+    async fn get_json<T: DeserializeOwned>(&mut self) -> Result<T, Box<dyn std::error::Error>>;
+
+    fn get_req_header<'a>(&'a self, header: &str) -> Option<&'a str>;
+}

--- a/thruster/src/context/context_ext.rs
+++ b/thruster/src/context/context_ext.rs
@@ -6,7 +6,7 @@ use crate::parser::tree::Params;
 #[async_trait]
 pub trait ContextExt {
     /// Get route params, e.g. /users/:id
-    fn get_params<'a>(&'a self) -> &'a Params;
+    fn params<'a>(&'a self) -> &'a Params;
 
     /// Set the response as JSON.
     ///
@@ -16,5 +16,6 @@ pub trait ContextExt {
     /// Gets the request body as JSON.
     async fn get_json<T: DeserializeOwned>(&mut self) -> Result<T, Box<dyn std::error::Error>>;
 
-    fn get_req_header<'a>(&'a self, header: &str) -> Option<&'a str>;
+    /// Retrieves a header from the incoming request object.
+    fn req_header<'a>(&'a self, header: &str) -> Option<&'a str>;
 }

--- a/thruster/src/context/fast_hyper_context.rs
+++ b/thruster/src/context/fast_hyper_context.rs
@@ -103,4 +103,8 @@ impl Context for FastHyperContext {
             .headers_mut()
             .remove(key);
     }
+
+    fn status(&mut self, code: u16) {
+        self.status = code;
+    }
 }

--- a/thruster/src/context/mod.rs
+++ b/thruster/src/context/mod.rs
@@ -17,3 +17,5 @@ pub mod basic_actix_context;
 
 #[cfg(feature = "actix_server")]
 pub mod actix_request;
+
+pub mod context_ext;

--- a/thruster/src/context/typed_hyper_context.rs
+++ b/thruster/src/context/typed_hyper_context.rs
@@ -100,7 +100,7 @@ impl<S: 'static + Send> TypedHyperContext<S> {
     ///
     /// Get the body as a string
     ///
-    pub async fn get_body(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+    pub async fn body_string(&mut self) -> Result<String, Box<dyn std::error::Error>> {
         let body = self.request_body.take().unwrap_or_else(|| {
             self.into_owned_request();
             self.request_body.take().unwrap()
@@ -301,7 +301,7 @@ impl<S: 'static + Send> HasCookies for TypedHyperContext<S> {
 
 #[async_trait]
 impl<S: 'static + Send> ContextExt for TypedHyperContext<S> {
-    fn get_params(&self) -> &Params {
+    fn params(&self) -> &Params {
         self.hyper_request.as_ref().unwrap().get_params()
     }
 
@@ -322,7 +322,7 @@ impl<S: 'static + Send> ContextExt for TypedHyperContext<S> {
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
     }
 
-    fn get_req_header<'a>(&'a self, header: &str) -> Option<&'a str> {
+    fn req_header<'a>(&'a self, header: &str) -> Option<&'a str> {
         self.parts()
             .headers
             .get(header)

--- a/thruster/src/context/typed_hyper_context.rs
+++ b/thruster/src/context/typed_hyper_context.rs
@@ -1,17 +1,19 @@
+use async_trait::async_trait;
 use bytes::Bytes;
-use futures::stream::StreamExt;
 use http::header::{HeaderMap, HeaderName, HeaderValue};
 use http::request::Parts;
-use hyper::{Body, Error, Response, StatusCode};
+use hyper::{Body, Response, StatusCode};
+use serde::de::DeserializeOwned;
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::str;
 
-use crate::context::hyper_request::HyperRequest;
+use crate::context::{context_ext::ContextExt, hyper_request::HyperRequest};
 use crate::core::context::Context;
+use crate::RequestWithParams;
 
 use crate::middleware::cookies::{Cookie, CookieOptions, HasCookies, SameSite};
 use crate::middleware::query_params::HasQueryParams;
+use crate::parser::tree::Params;
 
 pub struct TypedHyperContext<S: 'static + Send> {
     pub body: Body,
@@ -98,35 +100,15 @@ impl<S: 'static + Send> TypedHyperContext<S> {
     ///
     /// Get the body as a string
     ///
-    pub async fn get_body(self) -> Result<(String, TypedHyperContext<S>), Error> {
-        let ctx = match self.request_body {
-            Some(_) => self,
-            None => self.into_owned_request(),
-        };
+    pub async fn get_body(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+        let body = self.request_body.take().unwrap_or_else(|| {
+            self.into_owned_request();
+            self.request_body.take().unwrap()
+        });
 
-        let mut results = "".to_string();
-        let mut unwrapped_body = ctx.request_body.unwrap();
-        while let Some(chunk) = unwrapped_body.next().await {
-            // TODO(trezm): Dollars to donuts this is pretty slow -- could make it faster with a
-            // mutable byte buffer.
-            results = format!("{}{}", results, String::from_utf8_lossy(chunk?.as_ref()));
-        }
-
-        Ok((
-            results,
-            TypedHyperContext {
-                body: ctx.body,
-                query_params: ctx.query_params,
-                headers: ctx.headers,
-                status: ctx.status,
-                hyper_request: ctx.hyper_request,
-                request_body: Some(Body::empty()),
-                request_parts: ctx.request_parts,
-                extra: ctx.extra,
-                http_version: ctx.http_version,
-                cookies: ctx.cookies,
-            },
-        ))
+        Ok(String::from_utf8(
+            hyper::body::to_bytes(body).await?.to_vec(),
+        )?)
     }
 
     pub fn parts(&self) -> &Parts {
@@ -135,33 +117,15 @@ impl<S: 'static + Send> TypedHyperContext<S> {
             .expect("Must call `to_owned_request` prior to getting parts")
     }
 
-    pub fn into_owned_request(self) -> TypedHyperContext<S> {
-        match self.hyper_request {
-            Some(hyper_request) => {
-                let (parts, body) = hyper_request.request.into_parts();
+    pub fn into_owned_request(&mut self) {
+        let hyper_request = self.hyper_request.take().expect(
+            "`hyper_request` is None! That means `to_owned_request` has already been called",
+        );
+        let (parts, body) = hyper_request.request.into_parts();
 
-                TypedHyperContext {
-                    body: self.body,
-                    query_params: self.query_params,
-                    headers: self.headers,
-                    status: self.status,
-                    hyper_request: None,
-                    request_body: Some(body),
-                    request_parts: Some(parts),
-                    extra: self.extra,
-                    http_version: self.http_version,
-                    cookies: self.cookies,
-                }
-            }
-            None => self,
-        }
-    }
-
-    ///
-    /// Set the response status code
-    ///
-    pub fn status(&mut self, code: u32) {
-        self.status = code.try_into().unwrap();
+        self.hyper_request = None;
+        self.request_body = Some(body);
+        self.request_parts = Some(parts);
     }
 
     ///
@@ -291,6 +255,10 @@ impl<S: 'static + Send> Context for TypedHyperContext<S> {
     fn remove(&mut self, key: &str) {
         self.headers.remove(key);
     }
+
+    fn status(&mut self, code: u16) {
+        self.status = code;
+    }
 }
 
 impl<S: 'static + Send> HasQueryParams for TypedHyperContext<S> {
@@ -328,5 +296,36 @@ impl<S: 'static + Send> HasCookies for TypedHyperContext<S> {
             .iter()
             .map(|v| v.to_str().unwrap_or("").to_string())
             .collect()
+    }
+}
+
+#[async_trait]
+impl<S: 'static + Send> ContextExt for TypedHyperContext<S> {
+    fn get_params(&self) -> &Params {
+        self.hyper_request.as_ref().unwrap().get_params()
+    }
+
+    fn json<T: serde::Serialize>(&mut self, body: &T) -> Result<(), Box<dyn std::error::Error>> {
+        self.set("Content-Type", "application/json");
+        self.body = Body::from(serde_json::to_vec::<T>(body)?);
+
+        Ok(())
+    }
+
+    async fn get_json<T: DeserializeOwned>(&mut self) -> Result<T, Box<dyn std::error::Error>> {
+        let body = self.request_body.take().unwrap_or_else(|| {
+            self.into_owned_request();
+            self.request_body.take().unwrap()
+        });
+
+        serde_json::from_slice::<T>(&hyper::body::to_bytes(body).await?)
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+    }
+
+    fn get_req_header<'a>(&'a self, header: &str) -> Option<&'a str> {
+        self.parts()
+            .headers
+            .get(header)
+            .and_then(|v| v.to_str().ok())
     }
 }

--- a/thruster/src/core/context.rs
+++ b/thruster/src/core/context.rs
@@ -29,4 +29,9 @@ pub trait Context {
 
     /// remove is used to remove a header on the outgoing response.
     fn remove(&mut self, key: &str);
+
+    /// sets the status on the response.
+    fn status(&mut self, _status: u16) {
+        // Do nothing to not break compat
+    }
 }

--- a/thruster/src/core/errors.rs
+++ b/thruster/src/core/errors.rs
@@ -18,10 +18,20 @@ impl<C: Context> Error<C> for ThrusterError<C> {
 }
 
 pub trait ErrorSet<C> {
+    /// Error specifically caused by parsing the incoming requests.
     fn parsing_error(context: C, error: &str) -> ThrusterError<C>;
+
+    /// Generic error for generalized or obfuscated bad requests.
     fn generic_error(context: C) -> ThrusterError<C>;
+
+    /// Error used for unauthorized access.
     fn unauthorized_error(context: C) -> ThrusterError<C>;
+
+    /// Error when a resource is not found.
     fn not_found_error(context: C) -> ThrusterError<C>;
+
+    /// An error denoting a failure on the server side.
+    fn server_error(context: C) -> ThrusterError<C>;
 }
 
 impl<C: Context> ErrorSet<C> for ThrusterError<C> {
@@ -61,6 +71,16 @@ impl<C: Context> ErrorSet<C> for ThrusterError<C> {
         ThrusterError {
             context,
             message: "Not found".to_string(),
+            cause: None,
+        }
+    }
+
+    fn server_error(mut context: C) -> ThrusterError<C> {
+        context.status(500);
+
+        ThrusterError {
+            context,
+            message: "Server error".to_string(),
             cause: None,
         }
     }

--- a/thruster/src/integration_async_tests.rs
+++ b/thruster/src/integration_async_tests.rs
@@ -29,8 +29,8 @@
 // fn it_should_correctly_404_if_no_param_is_given() {
 //     let mut app = App::<Request, Ctx, ()>::new_basic();
 
-//     app.get("/test/:id", m!(Ctx, [test_fn_1]));
-//     app.set404(m!(Ctx, [test_fn_404]));
+//     app.get("/test/:id", m![test_fn_1]);
+//     app.set404(m![test_fn_404]);
 
 //     let _ = Runtime::new().unwrap().block_on(async {
 //         let response = testing::get(&app, "/test").await;

--- a/thruster/src/parser/tree.rs
+++ b/thruster/src/parser/tree.rs
@@ -121,12 +121,13 @@ impl<T: 'static + Context + Clone + Send> Default for Node<T> {
             path_piece: ROOT_ROUTE_ID.to_string(),
             param_name: None,
             children: vec![],
-            committed_middleware: Box::new(|c| {
+            committed_middleware: Box::new(|mut c| {
                 ReusableBoxFuture::new(async move {
+                    c.status(404);
+
                     Err(ThrusterError {
                         context: c,
                         message: "Not found".to_string(),
-                        status: 1,
                         cause: None,
                     })
                 })


### PR DESCRIPTION
Adds more examples for common cases like JSON, auth, and route params. Also does some cleanup in the code that caused some breaking changes (for example with error handling.) Because of the breaking changes, we've bumped the version to 1.3.0, which is not yet published.