### PR TITLE
chore: Update custom middleware example

### DIFF
--- a/thruster/examples/custom_middleware_with_auth.rs
+++ b/thruster/examples/custom_middleware_with_auth.rs
@@ -69,7 +69,8 @@ async fn authenticate(mut context: Ctx, next: MiddlewareNext<Ctx>) -> Middleware
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init();
     info!("Starting server...");
 
@@ -97,5 +98,5 @@ fn main() {
     .get("/hello", m![authenticate, hello]);
 
     let server = HyperServer::new(app);
-    server.start("0.0.0.0", 4321);
+    server.build("0.0.0.0", 4321).await;
 }


### PR DESCRIPTION
Now it will use the proper tokio macro for async main functions.