### PR TITLE
bug: Only include hyper body sometimes

### DIFF
--- a/thruster/src/app/mod.rs
+++ b/thruster/src/app/mod.rs
@@ -13,6 +13,7 @@ pub mod testing_async {
 
 use async_trait::async_trait;
 pub use httparse::Header;
+#[cfg(feature = "hyper_server")]
 use hyper::Body;
 pub use thruster_app::*;
 


### PR DESCRIPTION
We were accidentally including hyper's body at all times rather than only when hyper servers were enabled.