### PR TITLE
bug: Fix subtree wildcard propagation

### DIFF
--- a/thruster-proc/Cargo.toml
+++ b/thruster-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster-proc"
-version = "1.3.5"
+version = "1.3.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "The proc macros behind the thruster web framework"
 readme = "README.md"

--- a/thruster/Cargo.toml
+++ b/thruster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thruster"
-version = "1.3.5"
+version = "1.3.6"
 authors = ["Pete Mertz <peter.s.mertz@gmail.com>"]
 description = "A middleware based http async web server."
 readme = "../README.md"

--- a/thruster/src/app/thruster_app.rs
+++ b/thruster/src/app/thruster_app.rs
@@ -273,6 +273,8 @@ impl<R: 'static + ThrusterRequest, T: Context + Clone + Send + Sync, S: 'static 
         let method = request.method();
         let path = request.path();
 
+        println!("method: {method}");
+
         let node = match method {
             "OPTIONS" => self.options_root.get_value_at_path(path),
             "POST" => self.post_root.get_value_at_path(path),


### PR DESCRIPTION
Wildcards when using router were not getting propagated down through the added router tree when there were no nodes. This, in general, is an edge case, however when attempting to apply a method like OPTIONS for CORS handling, often a subtree will not have any explicit OPTIONS routes. Previously, when the call was made, the route tree would see a terminal node in the default root of the OPTIONS tree for the router, and would use the 404 middleware that nodes default to. Now, if a node is default (and therefore non-terminal) the tree structure looks to see if the node is terminal and, if not, attempts to apply any wildcards before passing back the default middleware.